### PR TITLE
Release v0.9.2: init agent flags + update binary download

### DIFF
--- a/internal/claudemd/generator.go
+++ b/internal/claudemd/generator.go
@@ -38,6 +38,30 @@ func (g *Generator) GenerateAll() ([]string, error) {
 	return created, nil
 }
 
+// GenerateSelected creates context files only for the specified agent names.
+// Returns a list of file paths that were created or modified.
+func (g *Generator) GenerateSelected(names []string) ([]string, error) {
+	selected := make(map[string]bool, len(names))
+	for _, n := range names {
+		selected[n] = true
+	}
+
+	var created []string
+	for _, af := range AgentFiles {
+		if !selected[af.Name] {
+			continue
+		}
+		ok, err := g.generateFile(af)
+		if err != nil {
+			return created, err
+		}
+		if ok {
+			created = append(created, af.Path)
+		}
+	}
+	return created, nil
+}
+
 // generateFile creates or appends the tene section to a single agent file.
 func (g *Generator) generateFile(af AgentFile) (bool, error) {
 	path := filepath.Join(g.projectDir, af.Path)

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -20,8 +20,32 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init [project-name]",
 	Short: "Initialize a new tene vault in the current project",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runInit,
+	Long: `Initialize a new tene vault and generate AI editor context files.
+
+By default, context files are generated for all supported AI editors:
+  CLAUDE.md, .cursor/rules/tene.mdc, .windsurfrules, GEMINI.md, AGENTS.md
+
+Use flags to generate only specific editor files:
+  tene init --claude --gemini     # Only CLAUDE.md and GEMINI.md
+  tene init --cursor              # Only .cursor/rules/tene.mdc`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runInit,
+}
+
+var (
+	initFlagClaude   bool
+	initFlagCursor   bool
+	initFlagWindsurf bool
+	initFlagGemini   bool
+	initFlagCodex    bool
+)
+
+func init() {
+	initCmd.Flags().BoolVar(&initFlagClaude, "claude", false, "Generate CLAUDE.md only")
+	initCmd.Flags().BoolVar(&initFlagCursor, "cursor", false, "Generate .cursor/rules/tene.mdc only")
+	initCmd.Flags().BoolVar(&initFlagWindsurf, "windsurf", false, "Generate .windsurfrules only")
+	initCmd.Flags().BoolVar(&initFlagGemini, "gemini", false, "Generate GEMINI.md only")
+	initCmd.Flags().BoolVar(&initFlagCodex, "codex", false, "Generate AGENTS.md only")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -143,7 +167,13 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// 12. Generate AI editor context files (CLAUDE.md, .cursor/rules/tene.mdc, etc.)
 	gen := claudemd.NewGenerator(dir)
-	agentFiles, _ := gen.GenerateAll()
+	selected := selectedAgents()
+	var agentFiles []string
+	if len(selected) > 0 {
+		agentFiles, _ = gen.GenerateSelected(selected)
+	} else {
+		agentFiles, _ = gen.GenerateAll()
+	}
 
 	// 13. Audit log
 	_ = v.AddAuditLog("vault.init", "", "project="+projectName)
@@ -187,7 +217,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		fmt.Println("  Next: tene set KEY VALUE to add your first secret.")
 		fmt.Println()
 		fmt.Println("  Tip: No server needed. Your secrets stay on this device.")
-		fmt.Println("       AI editors will automatically use tene.")
+		fmt.Println("       AI agents will automatically use tene.")
 	} else {
 		fmt.Println("Created .tene/vault.db")
 		if len(agentFiles) > 0 {
@@ -237,6 +267,27 @@ func joinWords(words []string) string {
 		result += w
 	}
 	return result
+}
+
+// selectedAgents returns agent names from init flags. Empty means all.
+func selectedAgents() []string {
+	var names []string
+	if initFlagClaude {
+		names = append(names, "claude")
+	}
+	if initFlagCursor {
+		names = append(names, "cursor")
+	}
+	if initFlagWindsurf {
+		names = append(names, "windsurf")
+	}
+	if initFlagGemini {
+		names = append(names, "gemini")
+	}
+	if initFlagCodex {
+		names = append(names, "codex")
+	}
+	return names
 }
 
 // Ensure json import is used

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 
@@ -69,11 +71,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	if flagJSON {
 		return printJSON(map[string]any{
-			"currentVersion": currentDisplay,
-			"latestVersion":  latest.TagName,
-			"targetVersion":  targetVersion,
+			"currentVersion":  currentDisplay,
+			"latestVersion":   latest.TagName,
+			"targetVersion":   targetVersion,
 			"updateAvailable": currentDisplay != latest.TagName && currentDisplay != "vdev",
-			"releaseUrl":     latest.HTMLURL,
+			"releaseUrl":      latest.HTMLURL,
 		})
 	}
 
@@ -94,18 +96,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Check if go is available
-	goPath, err := exec.LookPath("go")
-	if err != nil {
-		// No Go installed — suggest manual download
-		fmt.Println()
-		fmt.Printf("  Go is not installed. Download the binary manually:\n")
-		fmt.Printf("  https://github.com/tomo-kay/tene/releases/tag/%s\n", targetVersion)
-		fmt.Println()
-		fmt.Printf("  Or install Go first: https://go.dev/dl/\n")
-		return nil
-	}
-
 	// Confirm update
 	if isTerminal() && !flagQuiet {
 		fmt.Printf("\n  Update to %s? (y/N) ", targetVersion)
@@ -117,35 +107,120 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Run go install
-	installPath := fmt.Sprintf("github.com/tomo-kay/tene/cmd/tene@%s", targetVersion)
-	fmt.Printf("\n  Installing %s...\n", installPath)
+	// Resolve current binary path
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot determine binary path: %w", err)
+	}
 
-	goInstall := exec.Command(goPath, "install", installPath)
-	goInstall.Stdout = os.Stdout
-	goInstall.Stderr = os.Stderr
-	goInstall.Env = os.Environ()
+	// Download release binary from GitHub
+	versionNum := strings.TrimPrefix(targetVersion, "v")
+	assetName := fmt.Sprintf("tene_%s_%s_%s.tar.gz", versionNum, runtime.GOOS, runtime.GOARCH)
+	downloadURL := fmt.Sprintf("https://github.com/tomo-kay/tene/releases/download/%s/%s", targetVersion, assetName)
 
-	if err := goInstall.Run(); err != nil {
-		return fmt.Errorf("update failed: %w\n\n  Try manually: go install %s", err, installPath)
+	fmt.Printf("\n  Downloading %s...\n", assetName)
+
+	tmpBin, err := downloadBinaryFromTarGz(downloadURL)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	defer os.Remove(tmpBin)
+
+	// Replace current binary
+	if err := replaceBinary(binPath, tmpBin); err != nil {
+		return fmt.Errorf("failed to replace binary: %w\n\n  Try manually: curl -sSfL https://tene.sh/install.sh | sh", err)
 	}
 
 	fmt.Printf("\n  Updated to %s.\n", targetVersion)
 	fmt.Printf("  Run 'tene version' to verify.\n")
-
-	// Show PATH hint if needed
-	gobin := os.Getenv("GOBIN")
-	if gobin == "" {
-		gopath := os.Getenv("GOPATH")
-		if gopath == "" {
-			home, _ := os.UserHomeDir()
-			gopath = home + "/go"
-		}
-		gobin = gopath + "/bin"
-	}
-	fmt.Printf("\n  Binary location: %s/tene\n", gobin)
+	fmt.Printf("\n  Binary location: %s\n", binPath)
 
 	return nil
+}
+
+// downloadBinaryFromTarGz downloads a .tar.gz release asset and extracts the tene binary to a temp file.
+func downloadBinaryFromTarGz(url string) (string, error) {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("cannot download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("download returned HTTP %d (check version exists)", resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("invalid gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("invalid tar: %w", err)
+		}
+		if hdr.Name == "tene" && hdr.Typeflag == tar.TypeReg {
+			tmp, err := os.CreateTemp("", "tene-update-*")
+			if err != nil {
+				return "", err
+			}
+			if _, err := io.Copy(tmp, tr); err != nil {
+				_ = tmp.Close()
+				_ = os.Remove(tmp.Name())
+				return "", err
+			}
+			_ = tmp.Close()
+			if err := os.Chmod(tmp.Name(), 0755); err != nil {
+				_ = os.Remove(tmp.Name())
+				return "", err
+			}
+			return tmp.Name(), nil
+		}
+	}
+
+	return "", fmt.Errorf("tene binary not found in archive")
+}
+
+// replaceBinary atomically replaces the binary at dst with the one at src.
+func replaceBinary(dst, src string) error {
+	// Check write permission by opening for write
+	f, err := os.OpenFile(dst, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("no write permission on %s (try with sudo)", dst)
+	}
+	_ = f.Close()
+
+	// Rename is atomic on same filesystem; fall back to copy if cross-device
+	if err := os.Rename(src, dst); err != nil {
+		return copyFile(src, dst)
+	}
+	return nil
+}
+
+// copyFile copies src to dst, preserving executable permission.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return os.Chmod(dst, 0755)
 }
 
 func fetchLatestRelease() (*githubRelease, error) {


### PR DESCRIPTION
## Summary
- Add `--claude`, `--cursor`, `--windsurf`, `--gemini`, `--codex` flags to `tene init` for selective agent file generation
- Replace `go install` with GitHub Release binary download in `tene update` (fixes PATH mismatch and version detection)

## Test plan
- [ ] `tene init --gemini` generates only GEMINI.md
- [ ] `tene init --claude --cursor` generates only CLAUDE.md and .cursor/rules/tene.mdc
- [ ] `tene init` (no flags) generates all 5 files
- [ ] `tene init -h` shows agent flags and examples
- [ ] `tene update` downloads binary from GitHub Release and replaces in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)