### PR TITLE
feat: 3-tier pricing (Free / Solo $5 / Team $10)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -119,7 +119,7 @@ const jsonLd = {
           name: "Is Tene free?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Yes, Tene is 100% free and open source under the MIT license. There are no paid tiers, no usage limits, and no hidden costs.",
+            text: "Yes, Tene CLI is 100% free and open source under the MIT license. Local encrypted secret management has no limits. Cloud sync for multi-machine access starts at $5/month, and team sharing at $10/user/month.",
           },
         },
         {

--- a/apps/web/src/components/pricing.tsx
+++ b/apps/web/src/components/pricing.tsx
@@ -3,20 +3,20 @@ import { CopyCommand } from "./copy-command";
 import { WaitlistForm } from "./waitlist-form";
 import { GlowCard } from "./glow-card";
 
-// Design Ref: §4.1 — 2-column pricing with Free vs Cloud
 export function Pricing() {
   return (
     <section id="pricing" className="px-4 py-24 sm:px-6">
-      <div className="mx-auto max-w-4xl">
+      <div className="mx-auto max-w-5xl">
         <h2 className="text-center text-3xl font-bold sm:text-4xl">
           Free locally.{" "}
-          <span className="text-accent">$1/mo for cloud.</span>
+          <span className="text-accent">Cloud when you need it.</span>
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-center text-muted">
-          Local CLI is free forever. Cloud sync eliminates repeated setup across projects and machines.
+          Local CLI is free forever. Pay only for cloud sync and team
+          features.
         </p>
 
-        <div className="mt-16 grid gap-6 sm:grid-cols-2">
+        <div className="mt-16 grid gap-6 lg:grid-cols-3">
           {pricingTiers.map((tier) => (
             <GlowCard
               key={tier.name}
@@ -26,10 +26,10 @@ export function Pricing() {
                   : "border-border bg-surface"
               }`}
             >
-              <div className="relative z-10">
+              <div className="relative z-10 flex h-full flex-col">
                 <div className="flex items-center justify-between">
                   <h3 className="text-lg font-semibold">{tier.name}</h3>
-                  {tier.highlighted && (
+                  {tier.comingSoon && (
                     <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-0.5 text-xs text-yellow-400">
                       Coming Soon
                     </span>
@@ -37,13 +37,15 @@ export function Pricing() {
                 </div>
 
                 <div className="mt-4 flex items-baseline gap-1">
-                  <span className="text-4xl font-bold text-accent">{tier.price}</span>
+                  <span className="text-4xl font-bold text-accent">
+                    {tier.price}
+                  </span>
                   <span className="text-sm text-muted">/ {tier.period}</span>
                 </div>
 
                 <p className="mt-2 text-sm text-muted">{tier.description}</p>
 
-                <ul className="mt-6 space-y-3">
+                <ul className="mt-6 flex-1 space-y-3">
                   {tier.features.map((feature) => (
                     <li key={feature} className="flex items-start gap-2 text-sm">
                       <svg
@@ -61,18 +63,24 @@ export function Pricing() {
                 </ul>
 
                 <div className="mt-8">
-                  {tier.cta.action === "install" ? (
+                  {tier.cta.action === "install" && (
                     <CopyCommand
                       command="curl -sSfL https://tene.sh/install.sh | sh"
                       className="w-full justify-center text-xs"
                     />
-                  ) : (
-                    <WaitlistForm />
                   )}
                 </div>
               </div>
             </GlowCard>
           ))}
+        </div>
+
+        {/* Shared waitlist form */}
+        <div className="mx-auto mt-12 max-w-lg text-center">
+          <p className="mb-4 text-sm text-muted">
+            Interested in Solo or Team? Join the waitlist for early access.
+          </p>
+          <WaitlistForm />
         </div>
       </div>
     </section>

--- a/apps/web/src/data/faq.ts
+++ b/apps/web/src/data/faq.ts
@@ -25,7 +25,7 @@ export const faqs: FAQ[] = [
   {
     question: "Is Tene free?",
     answer:
-      "Yes, Tene CLI is 100% free and open source under the MIT license. Local encrypted secret management has no limits. Cloud sync for teams and multi-project is coming at $1/user/month.",
+      "Yes, Tene CLI is 100% free and open source under the MIT license. Local encrypted secret management has no limits. Cloud sync starts at $5/month for solo, $10/user/month for teams.",
   },
   {
     question: "Which AI Agents does Tene support?",
@@ -40,6 +40,6 @@ export const faqs: FAQ[] = [
   {
     question: "What is Cloud sync?",
     answer:
-      "Cloud sync (coming soon, $1/user/month) lets you manage secrets across multiple projects and machines without running tene init and tene set every time. Your secrets stay encrypted end-to-end.",
+      "Cloud sync (coming soon) lets you sync your encrypted vault across machines ($5/month solo) and share secrets with your team ($10/user/month). Zero-knowledge \u2014 the server never sees your secret values.",
   },
 ];

--- a/apps/web/src/data/pricing.ts
+++ b/apps/web/src/data/pricing.ts
@@ -1,4 +1,3 @@
-// Design Ref: §3.3 — Pricing tiers for Free vs Cloud
 export type PricingTier = {
   name: string;
   price: string;
@@ -7,6 +6,7 @@ export type PricingTier = {
   features: string[];
   cta: { label: string; action: "install" | "waitlist" };
   highlighted: boolean;
+  comingSoon: boolean;
 };
 
 export const pricingTiers: PricingTier[] = [
@@ -18,26 +18,45 @@ export const pricingTiers: PricingTier[] = [
     features: [
       "Unlimited secrets",
       "XChaCha20-Poly1305 encryption",
-      "AI runtime injection",
+      "AI runtime injection (5 agents)",
       "OS keychain integration",
       "12-word recovery key",
+      "Multi-environment support",
     ],
     cta: { label: "Install now", action: "install" },
     highlighted: false,
+    comingSoon: false,
   },
   {
-    name: "Cloud",
-    price: "$1",
-    period: "per user / month",
-    description: "Sync secrets across projects and machines.",
+    name: "Solo",
+    price: "$5",
+    period: "per month",
+    description: "Sync your vault across machines. No repeated setup.",
     features: [
       "Everything in Free",
-      "Cross-project sync",
-      "Cross-machine access",
-      "Team sharing",
-      "No repeated tene init",
+      "Cross-machine vault sync",
+      "Encrypted cloud backup",
+      "Device management",
+      "Personal audit log",
     ],
     cta: { label: "Join waitlist", action: "waitlist" },
     highlighted: true,
+    comingSoon: true,
+  },
+  {
+    name: "Team",
+    price: "$10",
+    period: "per user / month",
+    description: "Share secrets securely across your team.",
+    features: [
+      "Everything in Solo",
+      "Team secret sharing",
+      "Role-based access control",
+      "Environment-level permissions",
+      "Team audit log & dashboard",
+    ],
+    cta: { label: "Join waitlist", action: "waitlist" },
+    highlighted: false,
+    comingSoon: true,
   },
 ];

--- a/internal/cli/sync_cmd.go
+++ b/internal/cli/sync_cmd.go
@@ -29,11 +29,15 @@ func runSync(cmd *cobra.Command, args []string) error {
 	fmt.Println(`
   Tene Cloud Sync -- Coming Soon!
 
-  Cloud sync will enable:
-  - Multi-device secret synchronization
+  Solo ($5/month):
+  - Cross-machine vault sync
   - Encrypted cloud backup (zero-knowledge)
-  - Web dashboard for secret overview
-  - All for just $1/month
+  - Device management & audit log
+
+  Team ($10/user/month):
+  - Team secret sharing with RBAC
+  - Environment-level permissions
+  - Team dashboard & audit log
 
   Join the waitlist to get early access:
   -> https://tene.sh/waitlist


### PR DESCRIPTION
## Summary
- 2-tier → 3-tier pricing: Free $0, Solo $5/mo, Team $10/user/mo
- Both Solo and Team show "Coming Soon" badge
- Single shared waitlist form below pricing cards (removes duplicate forms)
- FAQ and SEO structured data updated to new pricing
- `tene sync` fake door message updated with Solo/Team details

## Test plan
- [ ] Pricing section shows 3 columns on desktop, stacked on mobile
- [ ] Both Solo and Team show "Coming Soon" badge
- [ ] Single waitlist form below cards works
- [ ] FAQ answers reflect new pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)