### PR TITLE
fix(ci): pin golangci-lint v2.1.6 for Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: "1.25"
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.1.6
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- golangci-lint `latest` (v1.64.8) was built with Go 1.24, incompatible with our Go 1.25 target
- Pin to `v2.1.6` which supports Go 1.25

## Test plan
- [x] CI lint job should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)