### PR TITLE
feat(infra): prod HA + staging environment

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,264 @@
+# Tene Architecture & Clean Code Guide
+
+## Monorepo Structure
+
+```
+tene/
+├── cmd/tene/              CLI entrypoint (main.go) → goreleaser → GitHub Releases
+├── cmd/server/            API server entrypoint (main.go) → Docker → ECR → ECS
+├── apps/web/              Landing page (Next.js 15) → Vercel (tene.sh)
+├── apps/dashboard/        Dashboard (Next.js 15) → Vercel (app.tene.sh)
+├── internal/              Go shared packages (not importable externally)
+├── infra/terraform/       AWS infrastructure (12+ modules)
+├── migrations/            PostgreSQL schema migrations (000001-000008)
+├── scripts/               dev.sh, sync-secrets.sh
+├── docs/                  PDCA documents (PM, Plan, Design, Report)
+└── .claude/rules/         AI agent context rules
+```
+
+## Clean Architecture Layers
+
+```
+Domain Layer (no external deps)
+  └── internal/domain/        Models: User, Vault, Team, Device, AuditLog
+  └── internal/errors/        CLI error codes with recovery suggestions
+
+Infrastructure Layer (external libs only)
+  └── internal/crypto/        XChaCha20-Poly1305, Argon2id, HKDF, X25519
+  └── internal/encfile/       Encrypted file format (header + ciphertext)
+  └── internal/recovery/      BIP-39 mnemonic generation/recovery
+  └── internal/keychain/      OS keychain (macOS/Linux) + file fallback
+  └── internal/vault/         SQLite CRUD, schema, migrations
+  └── internal/config/        CLI + global config management
+  └── internal/claudemd/      CLAUDE.md auto-generation (5 AI editors)
+
+Service Layer (business logic)
+  └── internal/auth/          OAuth (GitHub PKCE) + JWT (ES256, 15min/30day)
+  └── internal/billing/       LemonSqueezy integration + HMAC webhooks
+  └── internal/sync/          Push/pull engine, 3-way merge, Sync Envelope
+
+Interface Layer (user-facing)
+  └── internal/cli/           Cobra commands (25+ commands)
+  └── internal/api/           Echo server, routes, middleware
+  └── internal/api/handler/   HTTP handlers (auth, vault, team, billing, etc.)
+  └── internal/api/middleware/ JWT auth, rate limit, RBAC, security headers
+  └── internal/api/response/  Structured JSON responses
+  └── internal/api/storage/   S3 client for vault blobs
+```
+
+## Dependency Rules
+
+- `domain/` → imports ONLY stdlib (`errors`, `time`)
+- `crypto/`, `vault/`, `keychain/` → imports domain + external libs
+- `auth/`, `billing/`, `sync/` → imports crypto + domain
+- `api/handler/` → imports domain + auth + billing (via interfaces)
+- `cli/` → imports vault, sync, crypto, domain, errors, keychain, recovery, config
+- **No circular imports. No `api/` ↔ `cli/` cross-dependency.**
+
+## Interface Segregation
+
+Handlers depend on interfaces, not concrete types:
+
+```go
+// handler/vault.go
+type VaultStore interface {
+    CreateVault(v *domain.Vault) error
+    GetVault(id, userID string) (*domain.Vault, error)
+    ListVaults(userID string) ([]domain.Vault, error)
+    // ...
+}
+
+// handler/team.go
+type TeamStore interface {
+    CreateTeam(t *domain.Team) error
+    IsMember(teamID, userID string) bool
+    IsAdmin(teamID, userID string) bool
+    GetEnvPermissions(teamID, userID string) ([]string, error)
+    // ...
+}
+```
+
+In-memory stores (`MemVaultStore`, `MemTeamStore`) implement these for development.
+PostgreSQL stores will implement the same interfaces for production.
+
+## Dependency Injection
+
+All dependencies are injected via constructors in `api/server.go`:
+
+```go
+func NewServer(cfg Config) *echo.Echo {
+    jwtSvc := auth.NewJWTService(cfg.JWTSecret)
+    oauthSvc := auth.NewOAuthService(cfg.GitHubClientID, ...)
+    vaultStore := handler.NewMemVaultStore()  // swap for PG in prod
+    authH := handler.NewAuthHandler(oauthSvc, jwtSvc)
+    vaultH := handler.NewVaultHandler(vaultStore, s3Client)
+    // ...
+}
+```
+
+No global state, no service locators, no `init()` side effects.
+
+## API Routes
+
+```
+Public:
+  GET  /health                              Liveness check
+  GET  /health/ready                        Readiness check
+  GET  /api/v1/auth/github/authorize        OAuth initiation (PKCE)
+  GET  /api/v1/auth/github/callback         OAuth callback
+  POST /api/v1/auth/refresh                 Token rotation
+  POST /api/v1/billing/webhook              LemonSqueezy webhook (HMAC)
+  POST /api/v1/waitlist                     Waitlist registration
+
+Authenticated (JWT Bearer):
+  GET  /api/v1/auth/me                      Current user
+  POST /api/v1/auth/signout                 Revoke tokens
+  GET  /api/v1/vaults                       List vaults
+  POST /api/v1/vaults                       Create vault
+  POST /api/v1/vaults/:id/push             Push (50MB limit)
+  GET  /api/v1/vaults/:id/pull             Pull (presigned URL)
+  DELETE /api/v1/vaults/:id                Delete vault
+  GET  /api/v1/billing/subscription         Subscription status
+  POST /api/v1/billing/checkout             LemonSqueezy checkout
+  POST /api/v1/billing/portal              Customer portal
+  POST /api/v1/teams                       Create team
+  GET  /api/v1/teams                       List teams
+  POST /api/v1/teams/:id/invite            Invite member
+  DELETE /api/v1/teams/:id/members/:uid    Remove member
+  PATCH /api/v1/teams/:id/members/:uid/role Update role
+  POST /api/v1/devices                     Register device
+  GET  /api/v1/devices                     List devices
+  DELETE /api/v1/devices/:id               Delete device
+  GET  /api/v1/audit                       Audit logs
+```
+
+## Crypto Architecture
+
+```
+Master Password
+  → Argon2id (64MB, 3 iter, 4 threads) → Master Key (256-bit)
+    → HKDF-SHA256("encryption") → Encryption Key
+    → HKDF-SHA256("sync")       → Sync Key
+    → HKDF-SHA256("device")     → Device Key
+    → HKDF-SHA256("auth")       → Auth Hash
+
+Secret Encryption:
+  XChaCha20-Poly1305 (192-bit nonce, key name as AAD)
+
+Sync Envelope (L2):
+  Seal: SyncKey + AAD(projectID:env) → XChaCha20-Poly1305(vault.db)
+  Magic: "TENV" + version + nonce + ciphertext
+
+Team Key Wrapping:
+  X25519 ECDH → shared secret → HKDF(projectID) → wrap Project Key
+  Key rotation on member removal → re-wrap for remaining members
+
+Cloud 4-Layer Encryption:
+  L1: Secret values (XChaCha20-Poly1305)
+  L2: Sync Envelope (entire vault.db)
+  L3: TLS in transit
+  L4: S3 SSE-S3 (AES-256) at rest
+```
+
+## Sync Flow (Push/Pull/Merge)
+
+### Push
+1. Read local `vault.db` → Serialize secrets to JSON
+2. Seal with Sync Envelope (SyncKey + AAD `projectID:env`)
+3. SHA-256 hash for conflict detection
+4. Upload to `POST /vaults/:id/push` with `If-Match` (optimistic locking)
+5. S3 stores with SSE-S3 (L4)
+
+### Pull
+1. `GET /vaults/:id/pull` → presigned S3 URL (5-min TTL)
+2. Download + verify SHA-256 hash
+3. Open Sync Envelope (SyncKey + AAD)
+4. 3-way merge: base (last sync) vs local vs remote
+5. Update local vault.db
+
+### 3-Way Merge Rules
+```
+Base=A, Local=B, Remote=A → Local wins (only local changed)
+Base=A, Local=A, Remote=B → Remote wins (only remote changed)
+Base=A, Local=B, Remote=C → CONFLICT (both changed)
+Base=nil, Local=A         → Local addition
+Base=nil, Remote=A        → Remote addition
+Base=A, Local=nil, Remote=B → CONFLICT (deleted vs modified)
+```
+
+## Auth Flow
+
+### GitHub OAuth (PKCE)
+1. Generate PKCE verifier (32 bytes) + S256 challenge
+2. Generate random state (16 bytes), store with 5-min TTL
+3. Redirect to GitHub `/login/oauth/authorize`
+4. Callback: validate state → exchange code+verifier → fetch user
+5. Issue access token (15min) + refresh token (30day, SHA-256 hashed)
+
+### Token Refresh (H-04: Family Tracking)
+- Each refresh token belongs to a "family"
+- On use: old token deleted, new token issued with same family
+- Reuse detection: if token not found, revoke entire family
+
+### JWT Claims
+```go
+Subject: userID, Plan: "free"|"pro", DeviceID, Scope: "user"|"team"
+Issuer: "tene", Audience: "tene-api", JTI: unique ID
+```
+
+## CLI Commands (25+)
+
+| Command | Description |
+|---------|-------------|
+| `init [name]` | Create vault + master password + recovery key + CLAUDE.md |
+| `set KEY [VALUE]` | Encrypt and store (supports --stdin, --overwrite) |
+| `get KEY` | Decrypt and output |
+| `list` | List keys (values masked) |
+| `delete KEY` | Delete (supports --force) |
+| `run -- CMD` | Inject secrets as env vars |
+| `import FILE` | Bulk import (.env or encrypted) |
+| `export` | Export (.env or --encrypted) |
+| `env [name]` | Switch environment |
+| `passwd` | Change password (atomic 2-phase re-encrypt) |
+| `recover` | Restore via 12-word BIP-39 mnemonic |
+| `push` | Upload encrypted vault to cloud |
+| `pull` | Download and decrypt remote vault |
+| `sync` | Push + Pull combined (Pro) |
+| `login` | GitHub OAuth to Tene Cloud |
+| `logout` | Sign out + revoke tokens |
+| `team create` | Create team + generate project key |
+| `team invite` | Invite with X25519 wrapped key |
+| `team remove` | Remove + trigger key rotation |
+| `team list` | List teams |
+| `team members` | List team members |
+| `billing` | Subscription status |
+| `billing upgrade` | LemonSqueezy checkout |
+| `whoami` | Current user info |
+| `version` | Version info |
+| `update` | Check + install updates |
+
+Global flags: `--json`, `--quiet/-q`, `--env/-e`, `--dir`, `--no-color`, `--no-keychain`
+
+## Database Schema
+
+### PostgreSQL (Cloud) — 8 migrations
+
+| Table | Purpose |
+|-------|---------|
+| users | OAuth users, plan, public keys |
+| refresh_tokens | SHA-256 hashed, family tracking |
+| vaults | Cloud vault metadata, version, hash |
+| devices | X25519 public keys per device |
+| audit_logs | Partitioned by created_at |
+| waitlist | Email registration |
+| teams | Team entities with slugs |
+| team_members | Membership, roles, wrapped keys |
+
+### SQLite (Local) — internal/vault/schema.go
+
+| Table | Purpose |
+|-------|---------|
+| vault_meta | Key-value metadata (salt, recovery_blob) |
+| secrets | Encrypted name/value per environment |
+| environments | Environment management |
+| audit_log | Local operation history |

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -1,0 +1,153 @@
+# Tene Coding Conventions
+
+## Go Conventions
+
+### Naming
+- **Exported**: PascalCase (`DeriveSubKey`, `NewVault`)
+- **Unexported**: camelCase (`loadApp`, `resolveEnv`)
+- **Packages**: lowercase, single word (`crypto`, `vault`, `sync`)
+- **Test files**: `*_test.go` in same package
+- **Error constructors**: `New*` pattern (`NewSecretNotFound(key, env)`)
+
+### Error Handling
+```go
+// Always wrap with context
+return fmt.Errorf("vault: set secret: %w", err)
+
+// Sentinel errors per package
+var ErrNotFound = errors.New("not found")
+
+// CLI errors with codes and recovery hints
+var ErrVaultNotFound = &TeneError{
+    Code:    "VAULT_NOT_FOUND",
+    Message: "Not in a Tene project. Run \"tene init\" first.",
+    Exit:    1,
+}
+```
+
+### Unchecked Returns (errcheck)
+```go
+// defer Close — use closure pattern
+defer func() { _ = app.Vault.Close() }()
+
+// fmt.Fprint* in CLI output — assign to blank
+_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  Done\n")
+
+// Non-critical operations
+_ = os.Remove(tempFile)
+```
+
+### Error String Style (staticcheck ST1005)
+```go
+// Correct: lowercase, no trailing punctuation
+return fmt.Errorf("cannot create directory: %w", err)
+
+// Wrong:
+return fmt.Errorf("Cannot create directory: %w", err)  // capitalized
+return fmt.Errorf("no secrets found.")                   // trailing period
+```
+
+### Dependencies
+- No global mutable state — pass via struct fields
+- CLI flags are the exception (Cobra convention)
+- HTTP clients: package-level singletons (`var cliHTTPClient`)
+- All handler deps injected via constructors
+
+### Testing
+- Table-driven tests preferred
+- Test helpers in `testhelper_test.go`
+- Use `t.TempDir()` for isolation
+- Error returns in tests: `require.NoError(t, err)` or `_ = x()`
+
+## Linting — golangci-lint v2
+
+Config: `.golangci.yml` (version: "2")
+
+**Enabled linters:**
+- `errcheck` — unchecked error returns (check-type-assertions: true)
+- `govet` — suspicious constructs
+- `ineffassign` — useless assignments
+- `staticcheck` — advanced static analysis
+- `unused` — unused code
+- `misspell` — common misspellings
+- `exhaustive` — exhaustive switch (default-signifies-exhaustive: true)
+
+**CI**: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6`
+(Source-built with Go 1.25 — pre-built binaries use Go 1.24)
+
+## Frontend Conventions (Next.js 15)
+
+### Design System (Dark-only)
+```css
+--background: #0a0a0a;
+--foreground: #ededed;
+--accent: #00ff88;         /* neon green */
+--accent-dim: #00cc6a;
+--surface: #141414;
+--surface-2: #1e1e1e;
+--border: #2a2a2a;
+--muted: #888888;
+--danger: #ff4444;         /* dashboard only */
+--warning: #ffaa00;        /* dashboard only */
+```
+
+### Fonts
+- Primary: Geist Sans (via next/font/google)
+- Mono: Geist Mono
+- Fallback: Arial, Helvetica, sans-serif
+
+### Security Headers (both apps)
+```typescript
+// next.config.ts
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "https://api.tene.sh";
+// HSTS, X-Frame-Options: DENY, CSP (dynamic connect-src), Permissions-Policy
+```
+
+### Environment Variables
+```
+NEXT_PUBLIC_API_URL       API endpoint (default: https://api.tene.sh)
+NEXT_PUBLIC_DASHBOARD_URL Dashboard URL (local dev only)
+```
+
+### Dashboard Tech Stack
+- TanStack Query v5 — server state management
+- Zustand — auth state (access token)
+- Lucide React — icons
+- clsx — conditional classes
+
+### Component Patterns
+- Server Components by default (App Router)
+- Client Components only when needed (`"use client"`)
+- Semantic HTML with ARIA attributes
+- `<Link>` for internal navigation (not `<a>`)
+
+## Git Conventions
+
+### Branch Strategy
+```
+main → prod auto-deploy (protected, PRs only)
+feature/* → PR → Vercel Preview + CI
+hotfix/* → PR → fast merge → main → deploy
+```
+
+### Commit Messages
+```
+feat: new feature
+fix: bug fix
+fix(ci): CI/CD fix
+fix(lint): linter fixes
+docs: documentation
+refactor: code restructure
+```
+
+### CI Pipeline (GitHub Actions)
+```
+Push to main:
+  test (go test -race) + lint (golangci-lint v2) → deploy (Docker → ECR → ECS)
+
+Tag v*:
+  GoReleaser → GitHub Releases (multi-platform binaries)
+
+Dashboard changes:
+  TypeScript check + build verification → Vercel auto-deploy
+```

--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -1,0 +1,142 @@
+# Tene Secret Management (Dogfooding)
+
+Tene manages its own secrets using itself. Zero hardcoded credentials in the codebase.
+
+## Secret Flow by Environment
+
+```
+tene vault (source of truth)
+    │
+    ├── local:   tene run --env local -- go run ./cmd/server
+    │            → env vars injected directly to process
+    │
+    ├── staging: tene run --env staging -- ./scripts/sync-secrets.sh
+    │            → Tene vault → AWS Secrets Manager → ECS
+    │
+    └── prod:    tene run --env prod -- ./scripts/sync-secrets.sh
+                 → Tene vault → AWS Secrets Manager → ECS
+```
+
+## Required Secrets per Environment
+
+### Go API Server (`cmd/server/main.go`)
+
+| Key | Required | Source | Description |
+|-----|:--------:|--------|-------------|
+| JWT_SECRET | Yes | `envRequired()` | JWT signing (min 32 bytes) |
+| GITHUB_CLIENT_ID | No | `envOr("", "")` | GitHub OAuth App |
+| GITHUB_CLIENT_SECRET | No | `envOr("", "")` | GitHub OAuth App |
+| CALLBACK_BASE | No | default `http://127.0.0.1:8080` | OAuth callback base URL |
+| DASHBOARD_URL | No | default `https://app.tene.sh` | Post-checkout redirect |
+| S3_BUCKET | No | from Config | Vault blob storage |
+| S3_ENDPOINT | No | local MinIO only | S3-compatible endpoint |
+| AWS_REGION | No | from Config | AWS region |
+| DB_HOST | No | from ECS env | PostgreSQL host |
+| DB_PORT | No | default `5432` | PostgreSQL port |
+| DB_NAME | No | from ECS env | Database name |
+| DB_PASSWORD | No | from Secrets Manager | Database password |
+| LEMON_API_KEY | No | from Secrets Manager | LemonSqueezy API |
+| LEMON_WEBHOOK_SECRET | No | from Secrets Manager | Webhook HMAC |
+| LEMON_STORE_ID | No | from ECS env | Store identifier |
+| LEMON_VARIANT_PRO | No | from ECS env | Pro plan variant |
+
+### Frontend (`apps/dashboard/`, `apps/web/`)
+
+| Key | Where Set | Description |
+|-----|-----------|-------------|
+| NEXT_PUBLIC_API_URL | Vercel env / dev.sh | API endpoint |
+| NEXT_PUBLIC_DASHBOARD_URL | dev.sh only | Local dashboard URL |
+
+### Local Development
+
+```bash
+# All secrets are in tene vault (local environment)
+tene list --env local
+
+# API server gets secrets via tene run
+tene run --env local -- go run ./cmd/server
+
+# Frontend gets NEXT_PUBLIC_* via scripts/dev.sh inline
+NEXT_PUBLIC_API_URL=http://localhost:8080 npx next dev
+```
+
+### IMPORTANT: `tene run --env` Flag
+
+The `--env` flag in `tene run` is parsed manually before the `--` separator
+(due to `DisableFlagParsing: true` for child command passthrough).
+
+```bash
+# Correct — uses local environment
+tene run --env local -- go run ./cmd/server
+
+# Without --env — uses "default" environment (may have wrong values!)
+tene run -- go run ./cmd/server
+```
+
+## GitHub OAuth App Configuration
+
+| App | Client ID | Callback URL | Usage |
+|-----|-----------|--------------|-------|
+| Tene (Prod) | `Ov23li3Dnr6...` | `https://api.tene.sh/api/v1/auth/github/callback` | Production |
+| Tene Local | `Ov23litON0g...` | `http://localhost:8080/api/v1/auth/github/callback` | Local dev |
+
+**Critical**: Local vault must use the **Local** app's Client ID, not Production.
+Store in vault: `tene set GITHUB_CLIENT_ID "local-id" --env local`
+
+## CI/CD Secret Sources
+
+### GitHub Actions → ECS Deploy
+- AWS credentials: **OIDC** (no stored secrets) via `tene-prod-github-actions` role
+- Docker: builds from source, no secrets baked in
+
+### ECS Task Definition
+- **Environment vars**: non-sensitive (PORT, DB_HOST, S3_BUCKET, etc.)
+- **Secrets**: sensitive values from AWS Secrets Manager (`DB_PASSWORD`, `JWT_SECRET`, etc.)
+
+### Vercel (Frontend)
+- `NEXT_PUBLIC_API_URL` set in Vercel project settings
+- No other secrets needed (dashboard is client-side only)
+
+### Terraform
+```bash
+# Secrets passed via tene + TF_VAR_*
+TF_VAR_db_password="$(tene get DB_PASSWORD --env prod)" \
+TF_VAR_jwt_secret="$(tene get JWT_SECRET --env prod)" \
+terraform plan
+```
+
+## CORS Configuration
+
+CORS origins are environment-configurable (no localhost in production):
+
+```go
+// Default: production origins only
+corsOrigins := []string{"https://tene.sh", "https://app.tene.sh"}
+
+// Local dev: set CORS_EXTRA_ORIGINS env var
+// e.g., tene set CORS_EXTRA_ORIGINS "http://localhost:3000,http://localhost:3001" --env local
+```
+
+## Security Rules for AI Agents
+
+From `internal/claudemd/template.go`:
+1. Never hardcode secrets in source code
+2. Never create .env files
+3. Access secrets via `tene run -- <command>`
+4. Never run `tene get <KEY>` in AI conversations (values may leak)
+5. Never run `tene export` (outputs all plaintext to stdout)
+
+## .gitignore Rules
+
+```gitignore
+# Build binaries only (not source dirs!)
+/tene           # not cmd/tene/
+/server         # not cmd/server/
+/tene-dev
+
+# Secret-related
+.tene/          # local vault directory
+.env
+.env.*
+*.tene.enc
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
 
 permissions:
   contents: read
@@ -13,8 +13,6 @@ permissions:
 env:
   AWS_REGION: ap-northeast-2
   ECR_REPO: 507221376909.dkr.ecr.ap-northeast-2.amazonaws.com/tene-api
-  ECS_CLUSTER: tene-prod-cluster
-  ECS_SERVICE: tene-prod-api
 
 jobs:
   test:
@@ -41,10 +39,15 @@ jobs:
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
           golangci-lint run
 
-  deploy:
+  deploy-prod:
     runs-on: ubuntu-latest
     needs: [test, lint]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment: production
+    env:
+      ECS_CLUSTER: tene-prod-cluster
+      ECS_SERVICE: tene-prod-api
+      TASK_FAMILY: tene-prod-api
     steps:
       - uses: actions/checkout@v4
 
@@ -66,13 +69,46 @@ jobs:
       - name: Deploy to ECS
         run: |
           IMAGE_TAG="${{ github.sha }}"
-          # Get current task definition
-          TASK_DEF=$(aws ecs describe-task-definition --task-definition tene-prod-api --query taskDefinition)
-          # Update image in task definition
+          TASK_DEF=$(aws ecs describe-task-definition --task-definition $TASK_FAMILY --query taskDefinition)
           NEW_TASK_DEF=$(echo $TASK_DEF | jq --arg IMG "$ECR_REPO:$IMAGE_TAG" \
             '.containerDefinitions[0].image = $IMG | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
-          # Register new task definition
           NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF" --query 'taskDefinition.taskDefinitionArn' --output text)
-          # Update service
           aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --task-definition $NEW_ARN --force-new-deployment
-          echo "Deployed $IMAGE_TAG to ECS"
+          echo "Deployed $IMAGE_TAG to ECS (prod)"
+
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    if: github.ref == 'refs/heads/staging' && github.event_name == 'push'
+    environment: staging
+    env:
+      ECS_CLUSTER: tene-staging-cluster
+      ECS_SERVICE: tene-staging-api
+      TASK_FAMILY: tene-staging-api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::507221376909:role/tene-staging-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, push Docker image
+        run: |
+          IMAGE_TAG="${{ github.sha }}"
+          docker build --platform linux/amd64 -t $ECR_REPO:$IMAGE_TAG -f Dockerfile.server .
+          docker push $ECR_REPO:$IMAGE_TAG
+
+      - name: Deploy to ECS
+        run: |
+          IMAGE_TAG="${{ github.sha }}"
+          TASK_DEF=$(aws ecs describe-task-definition --task-definition $TASK_FAMILY --query taskDefinition)
+          NEW_TASK_DEF=$(echo $TASK_DEF | jq --arg IMG "$ECR_REPO:$IMAGE_TAG" \
+            '.containerDefinitions[0].image = $IMG | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF" --query 'taskDefinition.taskDefinitionArn' --output text)
+          aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --task-definition $NEW_ARN --force-new-deployment
+          echo "Deployed $IMAGE_TAG to ECS (staging)"

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -2,11 +2,11 @@ name: Dashboard
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "apps/dashboard/**"
   pull_request:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "apps/dashboard/**"
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ bin/
 /tene-dev
 
 # Terraform
-infra/terraform/environments/prod/.terraform/
-infra/terraform/environments/prod/terraform.tfstate*
+infra/terraform/environments/**/.terraform/
+infra/terraform/environments/**/terraform.tfstate*
 *.tfstate
 *.tfstate.backup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,10 @@ AI agents auto-detect secrets via CLAUDE.md generation.
 
 ## Rules (detailed guides)
 
-- [Environments & Infrastructure](.claude/rules/environments.md) — local/staging/prod 환경, 포트, 서비스, 아키텍처
+- [Architecture & Clean Code](.claude/rules/architecture.md) — 클린 아키텍처, 패키지 의존성, API 라우트, 암호화 체계, DB 스키마
+- [Coding Conventions](.claude/rules/conventions.md) — Go/Frontend 코딩 규칙, 린팅, 디자인 시스템, Git 전략
+- [Secret Management](.claude/rules/secrets.md) — tene 시크릿 주입, 환경별 설정, OAuth, CORS, CI/CD
+- [Environments & Infrastructure](.claude/rules/environments.md) — local/staging/prod 환경, 포트, 서비스, 네트워크
 - [Deployment Guide](.claude/rules/deployment.md) — 배포 절차, 롤백, 모니터링
 
 ## Architecture

--- a/infra/terraform/environments/staging/.terraform.lock.hcl
+++ b/infra/terraform/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.40"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -1,0 +1,160 @@
+locals {
+  project     = var.project
+  environment = var.environment
+  region      = var.aws_region
+}
+
+# ── VPC ────────────────────────────────────────────
+module "vpc" {
+  source = "../../modules/vpc"
+
+  project            = local.project
+  environment        = local.environment
+  vpc_cidr           = var.vpc_cidr
+  availability_zones = var.availability_zones
+}
+
+# ── NAT (fck-nat, ~$3/mo) ─────────────────────────
+module "nat" {
+  source = "../../modules/nat"
+
+  project                = local.project
+  environment            = local.environment
+  aws_region             = local.region
+  vpc_id                 = module.vpc.vpc_id
+  vpc_cidr               = var.vpc_cidr
+  public_subnet_id       = module.vpc.public_subnet_ids[0]
+  private_route_table_id = module.vpc.private_route_table_id
+}
+
+# ── ACM + DNS Validation ──────────────────────────
+module "acm" {
+  source = "../../modules/acm"
+
+  project          = local.project
+  environment      = local.environment
+  domain_name      = var.domain_name
+  subdomain_prefix = "api-staging"
+  san_prefixes     = ["app-staging"]
+}
+
+# ── S3 (vault blobs + ALB logs) ───────────────────
+module "s3" {
+  source = "../../modules/s3"
+
+  project     = local.project
+  environment = local.environment
+  aws_region  = local.region
+}
+
+# ── Secrets Manager ───────────────────────────────
+module "secrets" {
+  source = "../../modules/secrets"
+
+  project     = local.project
+  environment = local.environment
+  db_password = var.db_password
+  jwt_secret  = var.jwt_secret
+}
+
+# ── IAM ───────────────────────────────────────────
+module "iam" {
+  source = "../../modules/iam"
+
+  project              = local.project
+  environment          = local.environment
+  vault_bucket_arn     = module.s3.vault_bucket_arn
+  secrets_arn          = module.secrets.secret_arn
+  github_org           = var.github_org
+  github_repo          = var.github_repo
+  create_oidc_provider = false # OIDC provider already created by prod
+}
+
+# ── ALB ───────────────────────────────────────────
+module "alb" {
+  source = "../../modules/alb"
+
+  project                    = local.project
+  environment                = local.environment
+  vpc_id                     = module.vpc.vpc_id
+  public_subnet_ids          = module.vpc.public_subnet_ids
+  acm_certificate_arn        = module.acm.certificate_arn
+  enable_deletion_protection = false
+}
+
+# ── ECS Fargate (staging: cost-optimized) ─────────
+module "ecs" {
+  source = "../../modules/ecs"
+
+  project               = local.project
+  environment           = local.environment
+  aws_region            = local.region
+  vpc_id                = module.vpc.vpc_id
+  private_subnet_ids    = module.vpc.private_subnet_ids
+  ecr_repository_url    = data.aws_ecr_repository.api.repository_url
+  execution_role_arn    = module.iam.ecs_execution_role_arn
+  task_role_arn         = module.iam.ecs_task_role_arn
+  target_group_arn      = module.alb.target_group_arn
+  alb_security_group_id = module.alb.alb_security_group_id
+  db_host               = module.rds.address
+  db_name               = var.db_name
+  s3_bucket_name        = module.s3.vault_bucket_name
+  secrets_arn           = module.secrets.secret_arn
+
+  # Staging overrides: single instance, smaller spec
+  desired_count = 1
+  min_capacity  = 1
+  max_capacity  = 2
+  task_cpu      = 256
+  task_memory   = 512
+  callback_base = "https://api-staging.tene.sh"
+  dashboard_url = "https://app-staging.tene.sh"
+}
+
+# ── RDS PostgreSQL (staging: no Multi-AZ) ─────────
+module "rds" {
+  source = "../../modules/rds"
+
+  project               = local.project
+  environment           = local.environment
+  vpc_id                = module.vpc.vpc_id
+  isolated_subnet_ids   = module.vpc.isolated_subnet_ids
+  ecs_security_group_id = module.ecs.ecs_security_group_id
+  db_name               = var.db_name
+  db_username           = var.db_username
+  db_password           = var.db_password
+
+  # Staging: no Multi-AZ, minimal storage
+  multi_az = false
+}
+
+# ── ECR (shared with prod — reference existing repo) ─
+data "aws_ecr_repository" "api" {
+  name = "${local.project}-api"
+}
+
+# ── CloudWatch Alarms ─────────────────────────────
+module "cloudwatch" {
+  source = "../../modules/cloudwatch"
+
+  project     = local.project
+  environment = local.environment
+  aws_region  = local.region
+
+  ecs_cluster_name        = module.ecs.cluster_name
+  ecs_service_name        = module.ecs.service_name
+  rds_instance_id         = module.rds.instance_id
+  alb_arn_suffix          = module.alb.alb_arn_suffix
+  target_group_arn_suffix = module.alb.target_group_arn_suffix
+}
+
+# ── Route 53 (api-staging.tene.sh → ALB) ─────────
+module "route53" {
+  source = "../../modules/route53"
+
+  domain_name      = var.domain_name
+  route53_zone_id  = module.acm.route53_zone_id
+  alb_dns_name     = module.alb.alb_dns_name
+  alb_zone_id      = module.alb.alb_zone_id
+  subdomain_prefix = "api-staging"
+}

--- a/infra/terraform/environments/staging/outputs.tf
+++ b/infra/terraform/environments/staging/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" { value = module.vpc.vpc_id }
+output "ecr_repository_url" { value = data.aws_ecr_repository.api.repository_url }
+output "alb_dns_name" { value = module.alb.alb_dns_name }
+output "rds_endpoint" {
+  value     = module.rds.endpoint
+  sensitive = true
+}
+output "ecs_cluster" { value = module.ecs.cluster_name }
+output "ecs_service" { value = module.ecs.service_name }
+output "github_actions_role_arn" { value = module.iam.github_actions_role_arn }
+output "s3_vault_bucket" { value = module.s3.vault_bucket_name }

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -1,0 +1,60 @@
+variable "project" {
+  type    = string
+  default = "tene"
+}
+
+variable "environment" {
+  type    = string
+  default = "staging"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "ap-northeast-2"
+}
+
+variable "domain_name" {
+  type    = string
+  default = "tene.sh"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.1.0.0/16"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["ap-northeast-2a", "ap-northeast-2c"]
+}
+
+variable "db_name" {
+  type    = string
+  default = "tene"
+}
+
+variable "db_username" {
+  type    = string
+  default = "tene_admin"
+}
+
+# Sensitive — set via: TF_VAR_db_password or tene run -- terraform apply
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "jwt_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "github_org" {
+  type    = string
+  default = "tomo-kay"
+}
+
+variable "github_repo" {
+  type    = string
+  default = "tene"
+}

--- a/infra/terraform/environments/staging/versions.tf
+++ b/infra/terraform/environments/staging/versions.tf
@@ -8,11 +8,9 @@ terraform {
     }
   }
 
-  # To activate: run bootstrap first (see infra/terraform/bootstrap/)
-  # then uncomment this block and run: terraform init -migrate-state
   backend "s3" {
     bucket         = "tene-terraform-state-ap-northeast-2"
-    key            = "prod/terraform.tfstate"
+    key            = "staging/terraform.tfstate"
     region         = "ap-northeast-2"
     dynamodb_table = "tene-terraform-lock"
     encrypt        = true

--- a/infra/terraform/modules/acm/main.tf
+++ b/infra/terraform/modules/acm/main.tf
@@ -4,8 +4,8 @@ data "aws_route53_zone" "main" {
 }
 
 resource "aws_acm_certificate" "api" {
-  domain_name               = "api.${var.domain_name}"
-  subject_alternative_names = ["app.${var.domain_name}"]
+  domain_name               = "${var.subdomain_prefix}.${var.domain_name}"
+  subject_alternative_names = [for prefix in var.san_prefixes : "${prefix}.${var.domain_name}"]
   validation_method         = "DNS"
 
   lifecycle {

--- a/infra/terraform/modules/acm/variables.tf
+++ b/infra/terraform/modules/acm/variables.tf
@@ -1,3 +1,14 @@
 variable "project" { type = string }
 variable "environment" { type = string }
 variable "domain_name" { type = string }
+
+variable "subdomain_prefix" {
+  type    = string
+  default = "api"
+}
+
+variable "san_prefixes" {
+  description = "Additional subdomain prefixes for SAN entries"
+  type        = list(string)
+  default     = ["app"]
+}

--- a/infra/terraform/modules/alb/main.tf
+++ b/infra/terraform/modules/alb/main.tf
@@ -35,7 +35,7 @@ resource "aws_lb" "this" {
   security_groups    = [aws_security_group.alb.id]
   subnets            = var.public_subnet_ids
 
-  enable_deletion_protection = true
+  enable_deletion_protection = var.enable_deletion_protection
 
   tags = { Name = "${var.project}-${var.environment}-alb" }
 }

--- a/infra/terraform/modules/alb/variables.tf
+++ b/infra/terraform/modules/alb/variables.tf
@@ -9,3 +9,8 @@ variable "container_port" {
 }
 
 variable "acm_certificate_arn" { type = string }
+
+variable "enable_deletion_protection" {
+  type    = bool
+  default = true
+}

--- a/infra/terraform/modules/ecs/variables.tf
+++ b/infra/terraform/modules/ecs/variables.tf
@@ -27,12 +27,12 @@ variable "task_memory" {
 
 variable "desired_count" {
   type    = number
-  default = 1
+  default = 2
 }
 
 variable "min_capacity" {
   type    = number
-  default = 1
+  default = 2
 }
 
 variable "max_capacity" {

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -75,9 +75,19 @@ resource "aws_iam_role_policy" "ecs_execution_secrets" {
 
 # GitHub Actions OIDC
 resource "aws_iam_openid_connect_provider" "github" {
+  count           = var.create_oidc_provider ? 1 : 0
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 0 : 1
+  url   = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  oidc_provider_arn = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
 }
 
 resource "aws_iam_role" "github_actions" {
@@ -87,7 +97,7 @@ resource "aws_iam_role" "github_actions" {
     Version = "2012-10-17"
     Statement = [{
       Effect    = "Allow"
-      Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+      Principal = { Federated = local.oidc_provider_arn }
       Action    = "sts:AssumeRoleWithWebIdentity"
       Condition = {
         StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" }

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -4,3 +4,9 @@ variable "vault_bucket_arn" { type = string }
 variable "secrets_arn" { type = string }
 variable "github_org" { type = string }
 variable "github_repo" { type = string }
+
+variable "create_oidc_provider" {
+  description = "Whether to create the GitHub OIDC provider (only needed once per account)"
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/modules/route53/main.tf
+++ b/infra/terraform/modules/route53/main.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "api" {
   zone_id = var.route53_zone_id
-  name    = "api.${var.domain_name}"
+  name    = "${var.subdomain_prefix}.${var.domain_name}"
   type    = "A"
 
   alias {

--- a/infra/terraform/modules/route53/variables.tf
+++ b/infra/terraform/modules/route53/variables.tf
@@ -2,3 +2,8 @@ variable "domain_name" { type = string }
 variable "route53_zone_id" { type = string }
 variable "alb_dns_name" { type = string }
 variable "alb_zone_id" { type = string }
+
+variable "subdomain_prefix" {
+  type    = string
+  default = "api"
+}


### PR DESCRIPTION
## Summary

- **Prod HA**: RDS Multi-AZ, ECS min 2 tasks (multi-AZ), 10 CloudWatch alarms, TF state → S3
- **Staging environment**: Full infra at `api-staging.tene.sh` (cost-optimized ~$28/mo)
- **CI/CD**: staging branch push triggers `deploy-staging` job
- **Modules**: ACM/Route53/IAM/ALB parameterized for multi-env support

## Test plan

- [x] `terraform apply` prod — RDS Multi-AZ enabling, ECS scaled to 2, alarms created
- [x] `terraform apply` staging — all resources created successfully
- [x] GitHub staging branch created with protection rules
- [ ] Verify staging ECS tasks start after first image push

🤖 Generated with [Claude Code](https://claude.com/claude-code)