### PR TITLE
fix: OAuth login flow + CLI error messages

### DIFF
--- a/apps/dashboard/src/app/auth/callback/page.tsx
+++ b/apps/dashboard/src/app/auth/callback/page.tsx
@@ -14,6 +14,9 @@ export default function AuthCallbackPage() {
     const refreshToken = searchParams.get("refresh_token");
 
     if (accessToken && refreshToken) {
+      // Set cookie so Next.js middleware can verify auth on server-side
+      document.cookie = `tene_access_token=${accessToken}; path=/; max-age=${15 * 60}; SameSite=Lax`;
+      // Store in Zustand (persisted to localStorage)
       login(accessToken, refreshToken);
       router.replace("/");
     } else {

--- a/apps/dashboard/src/app/auth/callback/page.tsx
+++ b/apps/dashboard/src/app/auth/callback/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuthStore } from "@/lib/auth-store";
 
-export default function AuthCallbackPage() {
+function CallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const login = useAuthStore((s) => s.login);
@@ -25,11 +25,19 @@ export default function AuthCallbackPage() {
   }, [searchParams, login, router]);
 
   return (
+    <div className="text-center">
+      <h1 className="font-mono font-bold text-2xl text-accent mb-2">tene</h1>
+      <p className="text-muted text-sm">Signing you in...</p>
+    </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
     <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="font-mono font-bold text-2xl text-accent mb-2">tene</h1>
-        <p className="text-muted text-sm">Signing you in...</p>
-      </div>
+      <Suspense fallback={<p className="text-muted text-sm">Loading...</p>}>
+        <CallbackHandler />
+      </Suspense>
     </div>
   );
 }

--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-const publicPaths = ["/login"];
+const publicPaths = ["/login", "/auth/callback"];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/internal/api/handler/auth.go
+++ b/internal/api/handler/auth.go
@@ -21,7 +21,7 @@ const stateTTL = 5 * time.Minute
 
 type stateEntry struct {
 	codeVerifier string
-	redirectTo   string // "dashboard" or empty (API-only)
+	redirectTo   string // "dashboard", "cli:{port}", or empty (API-only)
 	expiresAt    time.Time
 }
 
@@ -90,10 +90,16 @@ func (h *AuthHandler) GitHubAuthorize(c echo.Context) error {
 	if err != nil {
 		return response.Err(c, err)
 	}
+	// Determine redirect target
+	redirectTo := c.QueryParam("redirect") // "dashboard" or empty
+	if port := c.QueryParam("callback_port"); port != "" {
+		redirectTo = "cli:" + port // CLI local callback server
+	}
+
 	h.mu.Lock()
 	h.states[state] = stateEntry{
 		codeVerifier: pkce.CodeVerifier,
-		redirectTo:   c.QueryParam("redirect"), // "dashboard" or empty
+		redirectTo:   redirectTo,
 		expiresAt:    time.Now().Add(stateTTL),
 	}
 	h.mu.Unlock()
@@ -173,7 +179,15 @@ func (h *AuthHandler) GitHubCallback(c echo.Context) error {
 		return c.Redirect(http.StatusTemporaryRedirect, redirectURL)
 	}
 
-	// CLI / API-only flow: return JSON
+	// If request came from CLI, redirect tokens to CLI's local callback server
+	if len(entry.redirectTo) > 4 && entry.redirectTo[:4] == "cli:" {
+		port := entry.redirectTo[4:]
+		redirectURL := fmt.Sprintf("http://127.0.0.1:%s/callback?access_token=%s&refresh_token=%s&user_id=%s&plan=%s",
+			port, accessToken, refreshToken, user.ID, user.Plan)
+		return c.Redirect(http.StatusTemporaryRedirect, redirectURL)
+	}
+
+	// API-only flow: return JSON
 	return response.OK(c, http.StatusOK, map[string]any{
 		"user": user,
 		"tokens": domain.TokenPair{

--- a/internal/cli/billing.go
+++ b/internal/cli/billing.go
@@ -174,14 +174,16 @@ func doAPIRequest(req *http.Request) (map[string]any, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	var apiResp struct {
-		OK   bool           `json:"ok"`
-		Data map[string]any `json:"data"`
+		OK      bool           `json:"ok"`
+		Error   string         `json:"error"`
+		Message string         `json:"message"`
+		Data    map[string]any `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if !apiResp.OK {
-		return nil, fmt.Errorf("API error (status %d)", resp.StatusCode)
+		return nil, fmt.Errorf("%s", apiErrMsg(apiResp.Error, apiResp.Message, resp.StatusCode))
 	}
 	return apiResp.Data, nil
 }

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -112,6 +112,17 @@ func decodeBase64(s string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(s)
 }
 
+// apiErrMsg builds a user-friendly error message from API error responses.
+func apiErrMsg(code, message string, status int) string {
+	if message != "" {
+		return message
+	}
+	if code != "" {
+		return fmt.Sprintf("%s (HTTP %d)", code, status)
+	}
+	return fmt.Sprintf("API error (HTTP %d)", status)
+}
+
 func encodeBase64(b []byte) string {
 	return base64.StdEncoding.EncodeToString(b)
 }

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,24 +56,22 @@ func runLogin(cmd *cobra.Command, args []string) error {
 				return
 			}
 
-			// Read the tokens from query params (returned by our API after OAuth)
-			code := r.URL.Query().Get("code")
-			state := r.URL.Query().Get("state")
+			// Read tokens directly from query params (API redirects with tokens after OAuth)
+			accessToken := r.URL.Query().Get("access_token")
+			refreshToken := r.URL.Query().Get("refresh_token")
+			userID := r.URL.Query().Get("user_id")
+			plan := r.URL.Query().Get("plan")
 
-			if code == "" {
+			if accessToken == "" {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = fmt.Fprint(w, "Missing code parameter")
-				errCh <- fmt.Errorf("missing code in callback")
+				_, _ = fmt.Fprint(w, "Missing access_token parameter")
+				errCh <- fmt.Errorf("missing access_token in callback")
 				return
 			}
 
-			// Exchange code via our API
-			result, err := exchangeCodeViaAPI(r.Context(), apiURL, code, state)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = fmt.Fprintf(w, "Login failed: %v", err)
-				errCh <- err
-				return
+			result := &loginResult{
+				User:   domain.User{ID: userID, Plan: plan},
+				Tokens: domain.TokenPair{AccessToken: accessToken, RefreshToken: refreshToken},
 			}
 
 			w.Header().Set("Content-Type", "text/html")
@@ -135,41 +132,6 @@ func runLogin(cmd *cobra.Command, args []string) error {
 type loginResult struct {
 	User   domain.User      `json:"user"`
 	Tokens domain.TokenPair `json:"tokens"`
-}
-
-func exchangeCodeViaAPI(ctx context.Context, apiURL, code, state string) (*loginResult, error) {
-	u, _ := url.Parse(apiURL + "/api/v1/auth/github/callback")
-	q := u.Query()
-	q.Set("code", code)
-	q.Set("state", state)
-	u.RawQuery = q.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("exchange code: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("exchange code: API returned %d", resp.StatusCode)
-	}
-
-	var apiResp struct {
-		OK   bool         `json:"ok"`
-		Data loginResult  `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
-		return nil, fmt.Errorf("exchange code: decode: %w", err)
-	}
-	if !apiResp.OK {
-		return nil, fmt.Errorf("exchange code: API error")
-	}
-
-	return &apiResp.Data, nil
 }
 
 func openBrowser(url string) error {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -130,8 +130,10 @@ func createVaultViaAPI(apiURL, token, projectName string) (string, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	var apiResp struct {
-		OK   bool `json:"ok"`
-		Data struct {
+		OK      bool   `json:"ok"`
+		Error   string `json:"error"`
+		Message string `json:"message"`
+		Data    struct {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
@@ -139,7 +141,7 @@ func createVaultViaAPI(apiURL, token, projectName string) (string, error) {
 		return "", fmt.Errorf("create vault: decode: %w", err)
 	}
 	if !apiResp.OK {
-		return "", fmt.Errorf("create vault: API error (status %d)", resp.StatusCode)
+		return "", fmt.Errorf("create vault: %s", apiErrMsg(apiResp.Error, apiResp.Message, resp.StatusCode))
 	}
 
 	return apiResp.Data.ID, nil

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -304,14 +304,16 @@ func runTeamRemove(cmd *cobra.Command, args []string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	var apiResp struct {
-		OK   bool           `json:"ok"`
-		Data map[string]any `json:"data"`
+		OK      bool           `json:"ok"`
+		Error   string         `json:"error"`
+		Message string         `json:"message"`
+		Data    map[string]any `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return fmt.Errorf("team remove: decode: %w", err)
 	}
 	if !apiResp.OK {
-		return fmt.Errorf("team remove: API error (status %d)", resp.StatusCode)
+		return fmt.Errorf("team remove: %s", apiErrMsg(apiResp.Error, apiResp.Message, resp.StatusCode))
 	}
 
 	if flagJSON {
@@ -372,14 +374,16 @@ func teamAPIPost(url, token string, body []byte) (map[string]any, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	var apiResp struct {
-		OK   bool           `json:"ok"`
-		Data map[string]any `json:"data"`
+		OK      bool           `json:"ok"`
+		Error   string         `json:"error"`
+		Message string         `json:"message"`
+		Data    map[string]any `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 	if !apiResp.OK {
-		return nil, fmt.Errorf("API error (status %d)", resp.StatusCode)
+		return nil, fmt.Errorf("%s", apiErrMsg(apiResp.Error, apiResp.Message, resp.StatusCode))
 	}
 	return apiResp.Data, nil
 }
@@ -398,14 +402,16 @@ func teamAPIGetList(url, token string) ([]map[string]any, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	var apiResp struct {
-		OK   bool             `json:"ok"`
-		Data []map[string]any `json:"data"`
+		OK      bool             `json:"ok"`
+		Error   string           `json:"error"`
+		Message string           `json:"message"`
+		Data    []map[string]any `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 	if !apiResp.OK {
-		return nil, fmt.Errorf("API error (status %d)", resp.StatusCode)
+		return nil, fmt.Errorf("%s", apiErrMsg(apiResp.Error, apiResp.Message, resp.StatusCode))
 	}
 	return apiResp.Data, nil
 }


### PR DESCRIPTION
## Summary
- OAuth callback redirects to dashboard or CLI local server (not raw JSON)
- Dashboard /auth/callback page with cookie + Zustand token storage
- CLI receives tokens directly from API (no double code exchange)
- All CLI API errors now include server error message

## Bugs Fixed
- Dashboard login showed raw JSON instead of redirecting
- CLI `tene login` hung at "Waiting for authentication..."
- CLI `tene push` showed "API error (status 402)" without explanation
- Dashboard middleware blocked /auth/callback

## Test plan
- [x] Local: dashboard GitHub OAuth login → Overview page
- [x] Local: CLI `tene login` → "Login successful!"
- [x] `go build ./...` + `golangci-lint` 0 issues + all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)