### PR TITLE
fix: Docker migrations path + graceful fallback

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -12,6 +12,7 @@ FROM alpine:3.21
 RUN apk add --no-cache ca-certificates wget tzdata \
     && adduser -D -u 1001 appuser
 COPY --from=builder /tene-api /usr/local/bin/tene-api
+COPY --from=builder /app/migrations /migrations
 USER appuser
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -73,9 +73,14 @@ func main() {
 
 // runMigrations applies pending database migrations from the migrations/ directory.
 func runMigrations(databaseURL string) {
-	m, err := migrate.New("file://migrations", databaseURL)
+	m, err := migrate.New("file:///migrations", databaseURL)
 	if err != nil {
-		log.Fatalf("migration init: %v", err)
+		// Try relative path (local dev)
+		m, err = migrate.New("file://migrations", databaseURL)
+	}
+	if err != nil {
+		log.Printf("migration init: %v (skipping migrations)", err)
+		return
 	}
 	defer func() {
 		srcErr, dbErr := m.Close()


### PR DESCRIPTION
## Summary
- Copy `migrations/` directory into Docker image (was missing → ECS crash on startup)
- Try `/migrations` (Docker absolute) then `./migrations` (local dev relative)  
- Migration failure is now non-fatal: log warning and continue serving

## Root Cause
ECS API logs show:
```
migration init: failed to open source, "file://migrations": open .: no such file or directory
```
New ECS tasks crashed on startup because `Dockerfile.server` only copied the binary, not the migrations directory. Old tasks continued serving with stale code.

## Test plan
- [x] `go build ./...` + `go test ./...` pass
- [ ] Docker build: `docker build -f Dockerfile.server .`
- [ ] ECS deploy + migration logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)