### PR TITLE
fix: Docker migrations, DB SSL, staging CORS

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -12,6 +12,7 @@ FROM alpine:3.21
 RUN apk add --no-cache ca-certificates wget tzdata \
     && adduser -D -u 1001 appuser
 COPY --from=builder /tene-api /usr/local/bin/tene-api
+COPY --from=builder /app/migrations /migrations
 USER appuser
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -73,9 +73,14 @@ func main() {
 
 // runMigrations applies pending database migrations from the migrations/ directory.
 func runMigrations(databaseURL string) {
-	m, err := migrate.New("file://migrations", databaseURL)
+	m, err := migrate.New("file:///migrations", databaseURL)
 	if err != nil {
-		log.Fatalf("migration init: %v", err)
+		// Try relative path (local dev)
+		m, err = migrate.New("file://migrations", databaseURL)
+	}
+	if err != nil {
+		log.Printf("migration init: %v (skipping migrations)", err)
+		return
 	}
 	defer func() {
 		srcErr, dbErr := m.Close()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -112,7 +112,7 @@ func buildDatabaseURL() string {
 	name := envOr("DB_NAME", "tene")
 	user := envOr("DB_USERNAME", "tene_admin")
 	pass := os.Getenv("DB_PASSWORD")
-	sslmode := envOr("DB_SSLMODE", "disable")
+	sslmode := envOr("DB_SSLMODE", "require")
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", user, pass, host, port, name, sslmode)
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -164,6 +164,10 @@ func NewServer(cfg Config) (*echo.Echo, func(), error) {
 	e.Use(echoMw.BodyLimit("2M")) // Default body limit for most routes
 	// M-03: CORS origins from environment (no localhost in prod)
 	corsOrigins := []string{"https://tene.sh", "https://app.tene.sh"}
+	// Auto-add staging origins when CALLBACK_BASE points to staging
+	if strings.Contains(cfg.CallbackBase, "staging") {
+		corsOrigins = append(corsOrigins, "https://staging.tene.sh", "https://app-staging.tene.sh")
+	}
 	if extra := os.Getenv("CORS_EXTRA_ORIGINS"); extra != "" {
 		corsOrigins = append(corsOrigins, strings.Split(extra, ",")...)
 	}


### PR DESCRIPTION
## Summary
Three infrastructure fixes discovered during staging QA:

1. **Docker migrations** — Copy `migrations/` into Docker image + graceful fallback on failure
2. **DB SSL** — Default `DB_SSLMODE=require` for RDS compatibility (local dev overrides to `disable`)
3. **Staging CORS** — Auto-detect staging from `CALLBACK_BASE` and add staging domains to CORS

Without these, ECS tasks crash on startup (no migrations dir), fail DB connection (SSL rejected), 
and block OAuth token exchange (CORS preflight denied).

## Test plan
- [x] All CI checks pass (lint, test, Vercel)
- [x] Staging ECS deploy: `database migrations applied` + `database.connected`
- [x] Staging OAuth login success

🤖 Generated with [Claude Code](https://claude.com/claude-code)