### PR TITLE
fix: create tags via GitHub API for Verified badge

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -82,12 +82,23 @@ jobs:
           echo "New version: $NEW_VERSION"
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Create tag
+      - name: Create tag (via GitHub API for Verified badge)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
-          git push origin "${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA=$(git rev-parse HEAD)
+          # Create tag object via API (GitHub signs it automatically → Verified)
+          gh api repos/${{ github.repository }}/git/tags \
+            -f tag="$VERSION" \
+            -f message="Release $VERSION" \
+            -f object="$SHA" \
+            -f type="commit" > /dev/null
+          # Create tag reference
+          gh api repos/${{ github.repository }}/git/refs \
+            -f ref="refs/tags/$VERSION" \
+            -f sha="$SHA" > /dev/null
+          echo "Tag $VERSION created (Verified)"
 
   goreleaser:
     needs: auto-tag


### PR DESCRIPTION
Test: GitHub API tag creation for Verified badge on personal account.