### PR TITLE
fix: exclude disabled cloud files from unused lint check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,3 +25,11 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
+    # Cloud commands disabled but code preserved for future re-enablement
+    - path: internal/cli/(login|logout|push|pull|sync_cmd|team|billing|helpers)\.go
+      linters:
+        - unused
+    - path: internal/cli/root\.go
+      text: "envOrDefault"
+      linters:
+        - unused


### PR DESCRIPTION
## Summary

- golangci-lint `unused` 체크에서 비활성화된 cloud 파일 제외
- 대상: login, logout, push, pull, sync_cmd, team, billing, helpers
- root.go의 `envOrDefault` 함수도 예외 처리

## Test plan

- [x] `go build ./cmd/tene` 성공
- [x] CI lint 에러 해결 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)