### PR TITLE
feat(release): enable Homebrew tap + harden LATEST_VERSION update

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -148,10 +148,19 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ needs.auto-tag.outputs.version }}
 
       - name: Update LATEST_VERSION (stable only)
-        if: "!contains(needs.auto-tag.outputs.version, '-rc')"
+        # Runs even when GoReleaser failed at a non-critical step (e.g. Homebrew
+        # formula publish) — we just need to verify the darwin/arm64 tarball
+        # actually exists at the target version before flipping the pointer,
+        # so install.sh never points at a missing release.
+        if: always() && !contains(needs.auto-tag.outputs.version, '-rc')
         run: |
           VERSION="${{ needs.auto-tag.outputs.version }}"
           VERSION="${VERSION#v}"
+          TARBALL="s3://${{ env.RELEASE_BUCKET }}/v${VERSION}/tene_${VERSION}_darwin_arm64.tar.gz"
+          if ! aws s3 ls "$TARBALL" > /dev/null 2>&1; then
+            echo "::error::Refusing to update LATEST_VERSION — $TARBALL not found on S3"
+            exit 1
+          fi
           echo "$VERSION" > /tmp/LATEST_VERSION
           aws s3 cp /tmp/LATEST_VERSION s3://${{ env.RELEASE_BUCKET }}/LATEST_VERSION \
             --content-type "text/plain" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,13 @@ and tene adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `.github/copilot-instructions.md`, `.github/FUNDING.yml`.
 - `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` (GitHub Community Health 42% → 90%+).
 - GitHub Issue templates (bug + feature) and PR template.
-- Homebrew tap (`brew install tomo-kay/tene/tene` · pending first release cut).
-- Docker image on GHCR (`docker run ghcr.io/tomo-kay/tene` · pending first release cut).
-- Man pages + shell completions bundled in release archives (pending first release cut).
+- Homebrew tap live: `brew install tomo-kay/tene/tene` (macOS + Linux). Tap
+  repository: [`tomo-kay/homebrew-tene`](https://github.com/tomo-kay/homebrew-tene).
+  First formula is published on the v1.0.6 release (v1.0.5 missed the initial
+  publish because the tap repository did not exist yet — see "Fixed" below).
+- Docker image on GHCR: `docker run ghcr.io/tomo-kay/tene:latest` (multi-arch
+  amd64 + arm64). Published from v1.0.5 onward.
+- Man pages + shell completions bundled in release archives (from v1.0.5).
 - Landing `/cli` public route with the full CLI reference.
 - Visual breadcrumb on `/vs/*` and `/blog/*` pages.
 - Trust section on homepage with live GitHub badges + maintainer bio.
@@ -56,3 +60,10 @@ and tene adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - `/vs/*` Schema.org `SoftwareApplication` node now conforms to spec.
+- `auto-tag.yml` workflow no longer skips the `LATEST_VERSION` S3 update when a
+  non-critical step inside GoReleaser fails (e.g. Homebrew formula publish
+  failing because the tap repo was missing). The update step now runs with
+  `if: always()` and guards against broken state by verifying the release
+  tarball exists on S3 before pointing `LATEST_VERSION` at it. Fixes the issue
+  where v1.0.5 binaries were uploaded successfully but `curl | sh` still
+  installed v1.0.4 because the pointer was never rewritten.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,34 @@ Auto-detects your OS and architecture, downloads the latest binary from GitHub R
 ### Other methods
 
 <details>
+<summary>With Homebrew (macOS + Linux)</summary>
+
+```bash
+brew install tomo-kay/tene/tene
+```
+
+Updates work as usual:
+
+```bash
+brew update && brew upgrade tene
+```
+
+Ships with shell completions (bash, zsh, fish) and the `tene(1)` man page.
+
+</details>
+
+<details>
+<summary>With Docker (GHCR)</summary>
+
+```bash
+docker run --rm ghcr.io/tomo-kay/tene:latest version
+```
+
+Multi-arch image (amd64 + arm64). Version-pinned tags: `v1`, `v1.0`, `v1.0.5`.
+
+</details>
+
+<details>
 <summary>With Go</summary>
 
 ```bash


### PR DESCRIPTION
## Summary

Wires up the Homebrew install path for macOS + Linux and fixes the workflow race that caused today's v1.0.5 install.sh hotfix.

### What changed

**Homebrew tap live**
- `tomo-kay/homebrew-tene` repo created (public, MIT) — empty until the next release publishes the first Formula.
- `.goreleaser.yml` already has the `brews:` section pointing at this repo. Next stable release (v1.0.6) will produce `Formula/tene.rb` with shell completions + man page wired in.
- README "Other methods" now documents `brew install tomo-kay/tene/tene` as first-class, alongside a Docker entry now that GHCR images ship.

**Workflow hardening** (`.github/workflows/auto-tag.yml`)
- "Update LATEST_VERSION" step now uses `if: always()` so a non-critical GoReleaser failure (Homebrew 401, Docker registry glitch, etc.) does not leave `install.sh` pointing at the previous version.
- Guard added: step refuses to flip the pointer unless the darwin_arm64 tarball for the new version actually exists on S3. Prevents the inverse failure (pointer advances to a release whose binaries never uploaded).
- Root cause captured in CHANGELOG.

**CHANGELOG**
- "Pending first release cut" wording removed from Homebrew/Docker/manpage entries — Docker + manpages shipped in v1.0.5; brew ships in v1.0.6 once the secret is set.
- New "Fixed" entry documenting the LATEST_VERSION race.

## Required before `brew install` works end-to-end

Two GitHub UI steps that can't be done via code:

1. **Create PAT** for `tomo-kay/homebrew-tene` write access
   - https://github.com/settings/tokens → Fine-grained tokens
   - Repository access: only `tomo-kay/homebrew-tene`
   - Permissions: `Contents: Read and write`, `Metadata: Read`
2. **Add secret** to `tomo-kay/tene` Actions
   ```
   gh secret set HOMEBREW_TAP_GITHUB_TOKEN --repo tomo-kay/tene --body "<PAT>"
   ```

Then the next release (v1.0.6 or a v1.0.5 re-run) publishes the Formula automatically.

## Test plan

- [x] Tap repo `tomo-kay/homebrew-tene` exists and is public
- [x] `.goreleaser.yml` brews section targets the correct owner/name
- [ ] CI passes on this PR (automatic)
- [ ] Vercel preview renders README install section cleanly
- [ ] After merge + PAT setup: v1.0.6 release publishes `Formula/tene.rb` to the tap
- [ ] `brew install tomo-kay/tene/tene` works on macOS arm64
- [ ] `brew install tomo-kay/tene/tene` works on Linux amd64
- [ ] `brew upgrade tene` picks up subsequent releases

## Related

- Follows PR #65 (v1.0.5 release chain).
- v1.0.5 `LATEST_VERSION` pointer was hotfixed manually on S3 (`1.0.4 → 1.0.5` at `Last-Modified: Thu, 23 Apr 2026 11:06:48 GMT`). This PR prevents that scenario from re-occurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)