### PR TITLE
feat(blog): 2-layer taxonomy (category + tag) + 2 new posts

### DIFF
--- a/apps/web/content/blog/ai-agents-and-human-responsibility.mdx
+++ b/apps/web/content/blog/ai-agents-and-human-responsibility.mdx
@@ -1,0 +1,314 @@
+---
+slug: ai-agents-and-human-responsibility
+title: "AI agents, human responsibility, and the harness in between"
+description: "Chatbots got good. Agents did not — not because the models aren't smart, but because the system around them isn't. Roles, responsibility, and why PDCA + L0–L4 control beats another model upgrade."
+publishedAt: "2026-04-24"
+updatedAt: "2026-04-24"
+category: philosophy
+tags: ["bkit", "workflow", "harness-engineering", "founder-story"]
+author: "tomo-kay"
+cover: "/og-image.png"
+canonicalUrl: "https://tene.sh/blog/ai-agents-and-human-responsibility"
+faqs:
+  - question: "If 90% of Anthropic's code is AI-written, why are they still hiring engineers?"
+    answer: "Because execution and accountability are separate jobs. AI handles the coding, testing, and debugging; humans decide what to build, why, for whom, and sign off when it's done. As AI takes over more execution, human time shifts from typing to judging — and judging is the part that carries legal, product, and customer-facing responsibility. The job title survives; the daily activity changes."
+  - question: "Is 'fully autonomous AI agent' a realistic goal for my product?"
+    answer: "Not in 2026. Every AI team shipping at scale — Anthropic, Cursor, GitHub — runs with graduated automation: routine steps auto-approved, high-stakes decisions gated through a human. The gain is not 'zero humans' but 'humans only at the decisions that actually need a human.' Binary thinking (manual vs fully auto) is the most common failure mode."
+  - question: "How does bkit's L0–L4 automation level differ from a config flag?"
+    answer: "A config flag is static — you turn it on, it stays on. L0–L4 is earned. Escalating from L2 to L3 requires a Trust Score derived from your project's actual track record (match rate, destructive-op count, interrupt frequency). The system graduates trust per project, not per user or per model, and a cooldown prevents a lucky streak from unlocking autonomy prematurely. It's closer to a pilot's flight-hour certification than a toggle."
+---
+
+## Chatbots are solved. Agents are not.
+
+A book I read recently put the difference cleanly:
+
+> A chatbot answers questions. An agent pursues goals.
+
+Most organizations already have chatbots. They work well enough.
+What they do not have — and what every roadmap pretends to have —
+is an agent: something that starts with an intent, makes decisions,
+executes, recovers from its own mistakes, and hands back a result a
+human can trust enough to sign off on.
+
+The gap between "AI that speaks well" and "AI that finishes work" is
+enormous. It's also, I think, where the next ten years of building
+happens. This piece is my attempt to draw the map of that gap — what
+changes about roles, what stays the same about responsibility, and
+why the harness around the model matters more than the model itself.
+
+## The structure is the bottleneck, not the model
+
+The most common conversation about AI in 2026 is still:
+
+- GPT-5 vs Claude 4.7 vs Gemini
+- Which model is smarter on benchmark X
+- Which one you should pick
+
+In practice, almost nobody running AI in production is blocked on
+model quality anymore. What they *are* blocked on, every single day:
+
+- The context is a mess, so the output drifts.
+- The intermediate state is lost, so the agent restarts from zero.
+- No one can tell why the model made the decision it made.
+- When something fails, recovery is manual and painful.
+
+None of those are model problems. They are **system** problems. They
+belong to the harness around the model, not to the model itself.
+Prompt engineering optimizes a single turn. Context engineering,
+workflow design, state management, and guardrails optimize the loop.
+That loop is where real systems live.
+
+The same book separates three architectural patterns that are too
+often conflated:
+
+- **RAG** is about *what information goes in* — retrieve the right
+  chunks and inject them.
+- **Workflow** is about *fixing the sequence* — step 1 always runs
+  before step 2, period.
+- **Agent** is about *choosing the next action* — given a goal and a
+  state, the model picks a move.
+
+Most teams today call something an "agent" when it's really a
+workflow with one model call in it. That's fine, sometimes — a fixed
+workflow is easier to debug — but it's worth being precise about what
+you're actually running.
+
+## More memory, not more knowledge
+
+The single best line I've read about agent design recently:
+
+> A good agent is not a system that knows more. It's a system that
+> remembers more appropriately.
+
+This is the correction to the "just stuff more into the context
+window" school. Bigger context does not mean better output; past a
+certain size, it usually means *worse* output. The right question is
+not "how much can I include" but "what is relevant *right now*?"
+
+That's what context engineering is. When, to which call, in which
+format, and at what scope — you inject exactly the information that
+moves the current decision forward. Everything else is noise. This is
+the difference between a senior engineer who knows what to look up
+when and a junior who Googles everything mid-sentence.
+
+## The two failure modes of automation
+
+Automation in AI has two popular endpoints, and both are broken.
+
+- **"The AI handles everything."** Things go wrong. The blast radius
+  is enormous. The organization has no idea what actually happened
+  until the bill or the incident.
+- **"A human must approve every step."** The agent becomes a slow,
+  expensive notification system. Humans spend all day clicking
+  approve on routine transitions. Nobody benefits.
+
+The middle path is obvious in hindsight: **graduated automation**.
+Automate the boring transitions, gate the meaningful decisions. Which
+is easy to say and hard to structure. It requires deciding, for each
+kind of decision, where it sits on the boring-to-meaningful
+continuum, and then keeping the policy consistent as the system grows.
+
+This is the problem bkit's `/control level 0` through `level 4`
+exists to solve. L0 is every-action-approved (first-run mode). L1 is
+suggestions plus mandatory checkpoints. L2 — the default — is
+routine-transitions-auto, key-decisions-gated. L3 is most-steps-auto,
+only-destructive-ops-gated. L4 is full autonomy.
+
+The graduation between levels isn't a config toggle. It's tied to a
+**Trust Score** derived from track record in the actual project:
+completed cycles, average match rate against the design doc,
+destructive-op count, interrupt frequency. Escalating to the next
+level comes with a cooldown. A lucky streak does not unlock autonomy;
+sustained reliability does. The structure is closer to a pilot's
+flight-hours certification than a dev-mode switch.
+
+## Humans are approvers, not reviewers
+
+The common framing is "human-in-the-loop" — the human sits in the
+middle of the pipeline and checks the AI's work. I think this
+undersells what's actually needed.
+
+In an organization, the human isn't a reviewer at a checkpoint. The
+human is the one who **defines the intent, approves the result, and
+carries the consequences**. Take any of those three away and you get:
+
+- Intent without human: an agent that solves the wrong problem beautifully.
+- Approval without human: automation nobody is accountable for.
+- Consequence without human: the system is a toy.
+
+The honest role split in 2026 looks closer to this:
+
+- **AI**: execution, verification, optimization. Does the work.
+- **Human**: intent, judgment, responsibility. Owns the outcome.
+
+The cleanest phrasing I've found:
+
+> AI can have a job. It cannot have a title. Because a title implies
+> accountability, and accountability doesn't delegate to a process.
+
+## The PDCA loop as the shape of an agent
+
+A useful shift is to stop describing agents as
+"autonomous-thing-that-does-tasks" and start describing them as
+**running an operating loop**:
+
+1. Read the current state.
+2. Choose the next action.
+3. Execute it.
+4. Evaluate the outcome.
+5. Update the plan.
+
+Which is, approximately, PDCA — Plan, Do, Check, Act. Or more
+precisely for software:
+
+- **Plan**: turn requirements into acceptance criteria
+- **Design**: commit to an approach
+- **Do**: implement it
+- **Check**: measure the result against the design
+- **Act**: iterate or ship
+
+Every serious AI-assisted development flow I've seen in production
+maps to this, even when nobody calls it PDCA. `bkit`'s `/pdca pm →
+plan → design → do → analyze → iterate → report` is one explicit
+encoding of it; Anthropic's internal Claude Code workflow is another.
+The word "PDCA" isn't the point. The point is that **agents need a
+state machine**, and a state machine means every output is tied to a
+phase, a spec, and a comparison.
+
+The benefit of making the loop explicit is *auditability*. When the
+agent does something surprising, you can walk backward: which plan
+phase did this come out of, what spec was it written against, what
+did the check return, why did the iterate pass? Without an explicit
+loop, every surprise is a mystery. With it, every surprise is an
+entry in a state machine log.
+
+## Data point: where AI-native organizations actually are
+
+If you want to calibrate how fast this is moving, look at the
+organizations that use AI on themselves most aggressively.
+
+**Anthropic.** Dario Amodei has said publicly that ~90% of code
+across most teams is now written by Claude. Boris Cherny, who leads
+Claude Code, has described writing *100%* of his own recent code with
+AI and running multiple Claude sessions in parallel. Claude Code
+itself is reportedly ~90% Claude-written.
+
+**Y Combinator.** YC partners have reported some portfolio companies
+hitting 95% AI-generated code. The interesting detail is not the
+percentage; it's the implication for headcount. A seed-stage startup
+that would have needed 5 engineers now needs 2, but those 2 are doing
+radically different work than engineers did in 2022.
+
+**OpenAI.** Sam Altman's framing — "the future of AI depends on good
+governance" — isn't just a PR line. Governance in this context means
+concrete questions: what data can the AI access, what decisions can
+it make unsupervised, who owns the output. These are *organizational*
+questions dressed in technical clothing.
+
+Three different companies, one consistent pattern: **AI takes more
+and more of the execution; the humans left do more specification and
+more approval.**
+
+## What happens to the org chart
+
+The observable shift in these companies, and increasingly in the
+startups watching them, is not "engineers get replaced." It's
+subtler:
+
+- **Execution roles shrink.** Not to zero — the work still happens,
+  it's just that one person running five AI sessions produces the
+  throughput of a former team.
+- **Manager roles compress.** A significant chunk of manager work is
+  translation — turning an executive ask into a plan, turning an
+  engineer's update into a dashboard, reviewing docs, maintaining
+  timelines. AI does a lot of that now.
+- **Executive / owner roles expand.** Someone still has to decide
+  what to build, prioritize between competing directions, deal with
+  customers, and answer when something blows up. None of that
+  delegates to an AI because none of it is an execution task.
+
+A sketch of the 2030-ish shape:
+
+```
+Board          — AI governance, data policy, risk
+  ↓
+C-level        — system architect, not resource allocator
+  ↓
+Executive      — decision + accountability
+  ↓
+Expert + AI    — execution at scale
+```
+
+The thing to notice: **the org chart is flatter, but the
+accountability chart is taller**. Fewer people are in the chain of
+command, and each person in the chain owns more of the outcome. AI
+expands what one expert can do; it does not expand who the
+responsibility lands on.
+
+## Why bkit exists
+
+I'll be direct: the design of `bkit` is a reaction to the pattern
+above.
+
+If the problem isn't "the model isn't smart enough" but "the system
+around the model isn't disciplined enough," then the answer isn't a
+better model. The answer is:
+
+1. An **explicit state machine** so every step has a phase, a spec,
+   and a measurable outcome.
+2. **Graduated automation** so humans are gated on the decisions that
+   need them, and nowhere else.
+3. A **match-rate loop** that makes "is the implementation faithful
+   to the design?" a measurable quantity, not a vibes-based review.
+
+That's what `/pdca pm → design → do → analyze → iterate → report` is
+— a state machine with acceptance criteria at every phase. That's
+what `gap-detector` + 90% match-rate threshold is — the system
+refuses to ship until implementation and design agree. That's what
+the L0–L4 levels plus Trust Score are — graduated automation earned
+per project, reversible in one command.
+
+None of it makes the model smarter. All of it makes the *outcome*
+more reliable, more auditable, and — the part that matters for
+accountability — more defensible when a human has to sign off.
+
+## The thing AI won't replace
+
+I started writing `tene` — the open-source CLI that injects secrets
+into AI agents without letting them see the plaintext — because of a
+concrete fear: my own API keys leaking into a chat log. I kept
+building `bkit` on top for a more philosophical reason: I don't
+actually believe AI is going to replace the act of *deciding*. It
+might replace most of the typing, most of the debugging, most of the
+writing up. But the sentence "we are shipping this" still has to be
+said by a person who can still be fired for saying it.
+
+The harness matters because that sentence is only credible if the
+system underneath it is legible. If you can't explain why the AI made
+the decision it made, you can't stand behind its output. If you
+can't stand behind it, you shouldn't have shipped it. And if nobody
+is willing to stand behind it, you didn't actually ship — you
+demoed.
+
+Demos run on applause. Products run on accountability. The difference
+is the loop.
+
+## Takeaways
+
+- Chatbots are solved. Agents are a structural problem, not a model
+  problem. Upgrading the model does not fix a weak harness.
+- The honest role split: **AI executes, verifies, optimizes. Humans
+  intend, judge, and are accountable.**
+- The two failure modes — full-auto and nothing-auto — are both
+  broken. Graduated automation (L0–L4) is the middle path.
+- A good agent is a **state machine + match-rate loop**, not a
+  cleverer prompt. PDCA is one explicit encoding.
+- The org chart flattens while the accountability chart gets taller.
+  AI is spreadable; responsibility is not.
+- The next three years aren't about building bigger models. They're
+  about building systems a human can still sign off on.
+
+Related reading:
+- [bkit + harness engineering: workflow beats model choice](/blog/bkit-harness-engineering-vibe-coding)
+- [bkit: PDCA methodology for Claude Code](/blog/bkit-pdca-for-claude-code)
+- [Why I stopped using Doppler](/blog/doppler-alternative-journey)

--- a/apps/web/content/blog/ai-reads-env.mdx
+++ b/apps/web/content/blog/ai-reads-env.mdx
@@ -4,7 +4,8 @@ title: "Your .env is not a secret. AI can read it."
 description: "Plaintext .env files are a liability in the AI coding era. Here is why the AI-agent threat model changes the math, and what to replace .env with."
 publishedAt: "2026-04-23"
 updatedAt: "2026-04-23"
-tags: ["security", "ai", "devsecops"]
+category: vibe-coding
+tags: ["security", "devsecops", "tene"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/ai-reads-env"

--- a/apps/web/content/blog/bkit-harness-engineering-vibe-coding.mdx
+++ b/apps/web/content/blog/bkit-harness-engineering-vibe-coding.mdx
@@ -4,7 +4,8 @@ title: "bkit + harness engineering: workflow beats model choice"
 description: "Why the workflow around Claude Code matters more than picking a bigger model. Harness engineering, bkit's PDCA, and L0–L4 trust-graduated automation."
 publishedAt: "2026-04-23"
 updatedAt: "2026-04-23"
-tags: ["vibe-coding", "ai", "architecture"]
+category: vibe-coding
+tags: ["bkit", "harness-engineering", "workflow"]
 author: "tomo-kay"
 cover: "/blog/bkit-harness-engineering-vibe-coding/bkit-og.png"
 canonicalUrl: "https://tene.sh/blog/bkit-harness-engineering-vibe-coding"

--- a/apps/web/content/blog/bkit-pdca-for-claude-code.mdx
+++ b/apps/web/content/blog/bkit-pdca-for-claude-code.mdx
@@ -4,7 +4,8 @@ title: "bkit: PDCA methodology for Claude Code"
 description: "bkit encodes PDCA methodology into Claude Code: Skills, Agents, Hooks, MCP, and a state machine with quality gates from plan to report."
 publishedAt: "2026-04-23"
 updatedAt: "2026-04-23"
-tags: ["tutorial", "ai", "vibe-coding"]
+category: vibe-coding
+tags: ["bkit", "workflow", "tutorial", "claude-code"]
 author: "tomo-kay"
 cover: "/blog/bkit-pdca-for-claude-code/bkit-og.png"
 canonicalUrl: "https://tene.sh/blog/bkit-pdca-for-claude-code"

--- a/apps/web/content/blog/claude-code-safe-api-keys.mdx
+++ b/apps/web/content/blog/claude-code-safe-api-keys.mdx
@@ -4,7 +4,8 @@ title: "Claude Code + API keys: the safe workflow"
 description: "A practical pattern for using Claude Code with real API keys without leaking them into the context window. Covers CLAUDE.md auto-generation, 'tene run --' subshell, and concrete Stripe / OpenAI examples."
 publishedAt: "2026-04-23"
 updatedAt: "2026-04-23"
-tags: ["ai", "security", "tutorial", "vibe-coding"]
+category: vibe-coding
+tags: ["tene", "claude-code", "security", "tutorial"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/claude-code-safe-api-keys"

--- a/apps/web/content/blog/cursor-secret-management-2026.mdx
+++ b/apps/web/content/blog/cursor-secret-management-2026.mdx
@@ -4,7 +4,8 @@ title: "Cursor + secret management in 2026"
 description: "How to set up Cursor so API keys stay out of the AI context, using the .cursor/rules/tene.mdc file to teach the agent the safe pattern."
 publishedAt: "2026-04-20"
 updatedAt: "2026-04-20"
-tags: ["ai", "security", "vibe-coding", "tutorial"]
+category: vibe-coding
+tags: ["tene", "cursor", "security", "tutorial"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/cursor-secret-management-2026"

--- a/apps/web/content/blog/doppler-alternative-journey.mdx
+++ b/apps/web/content/blog/doppler-alternative-journey.mdx
@@ -4,7 +4,8 @@ title: "Why I stopped using Doppler"
 description: "Doppler is a good product. This is not a hit piece. It is an honest walk through why a solo developer moved off it to a local-first vault — and why you might too, or might not."
 publishedAt: "2026-04-18"
 updatedAt: "2026-04-18"
-tags: ["comparison", "devsecops", "security"]
+category: tools
+tags: ["tene", "comparison", "founder-story"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/doppler-alternative-journey"

--- a/apps/web/content/blog/dotenv-vault-alternatives.mdx
+++ b/apps/web/content/blog/dotenv-vault-alternatives.mdx
@@ -4,7 +4,8 @@ title: "dotenv-vault is shutting down. Here's what to migrate to."
 description: "The dotenv-vault Pro tier was discontinued in February 2026. Here is a honest side-by-side of the migration options — Doppler, Infisical, HashiCorp Vault, and tene — and a one-command path off the old product."
 publishedAt: "2026-04-23"
 updatedAt: "2026-04-23"
-tags: ["devsecops", "security", "comparison", "tutorial"]
+category: tools
+tags: ["tene", "comparison", "tutorial", "devsecops"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/dotenv-vault-alternatives"

--- a/apps/web/content/blog/migrate-env-60s.mdx
+++ b/apps/web/content/blog/migrate-env-60s.mdx
@@ -4,7 +4,8 @@ title: "Migrating from .env to an encrypted vault in 60 seconds"
 description: "A hands-on tutorial: take an existing .env file, import it into an encrypted vault, and get your app running through runtime injection. No code changes needed."
 publishedAt: "2026-04-22"
 updatedAt: "2026-04-22"
-tags: ["tutorial", "devsecops", "cli"]
+category: tools
+tags: ["tene", "tutorial", "cli"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/migrate-env-60s"

--- a/apps/web/content/blog/web-basics-for-vibe-coders.mdx
+++ b/apps/web/content/blog/web-basics-for-vibe-coders.mdx
@@ -1,0 +1,343 @@
+---
+slug: web-basics-for-vibe-coders
+title: "Web basics for vibe coders: from localhost to production"
+description: "AI wrote your code. Now how do you ship it to the internet? A plain-language tour of client/server, frontend/backend, database, deployment, and the security gap most AI tutorials skip."
+publishedAt: "2026-04-24"
+updatedAt: "2026-04-24"
+category: engineering
+tags: ["architecture", "tutorial", "security", "tene"]
+author: "tomo-kay"
+cover: "/og-image.png"
+canonicalUrl: "https://tene.sh/blog/web-basics-for-vibe-coders"
+faqs:
+  - question: "I built an app with AI. Why can't my friends use it?"
+    answer: "Your app is running on localhost — a loopback address that only resolves on your own machine. 'Shipping' means running that code on a server that's reachable from the public internet at a stable URL. Vercel, Fly.io, Railway, and AWS all solve this in different ways; the one-click options are fine to start."
+  - question: "Do I really need a backend? My app only has a few pages."
+    answer: "No, not always. If your pages are purely static content (marketing site, blog, portfolio), a frontend on Vercel is enough. You need a backend the moment you store data per user, call a paid API that must keep its key secret, or process payments. The moment you have an API key that must not leak, you also inherit the secret-management problem."
+  - question: "Can my AI agent see my .env file while coding?"
+    answer: "Yes, by default. Claude Code, Cursor, Windsurf, and similar tools index project files to build context — .env at the project root is included unless explicitly excluded. This is the biggest security gap in the vibe-coder workflow, and the reason tene exists."
+---
+
+## The moment AI finishes your app
+
+You open a chat window. You describe a todo app. Twenty minutes later
+you have working code on your laptop. You click, it works, you click
+again, it works. And then you hit the wall every vibe coder hits:
+
+**"How do my friends actually use this?"**
+
+The demo lives at `http://localhost:3000`. That address resolves to
+*your laptop, only*. Close the tab, kill the process, turn off the
+Wi-Fi — it's gone. To make the app live on the real internet you need
+to understand a handful of concepts that AI tutorials usually skip over.
+This guide walks you through them in plain language, in the rough order
+you'll actually encounter them, and flags one security trap most
+step-by-step tutorials get wrong.
+
+## The whole stack as one restaurant
+
+A web service is a restaurant. Keep that in your head and everything
+below slots into place:
+
+| Restaurant | Web service | Role |
+|---|---|---|
+| Customer | Browser / mobile app | Uses the service |
+| Front of house | **Frontend** | What the customer sees and touches |
+| Kitchen | **Backend** | Where actual work happens |
+| Fridge / pantry | **Database** | Stores structured data |
+| Wine cellar | **File storage** | Stores big items (images, videos) |
+| Road to the restaurant | **Network + HTTPS** | How the customer arrives safely |
+| Rented building | **Infrastructure** | Server, power, water — the substrate |
+| Opening the doors | **Deployment** | Making it reachable by anyone |
+
+The words in bold each map to a separate topic below. The analogy will
+stop being useful eventually — physical restaurants don't have
+copy-paste-able APIs — but it's a good scaffold for the first month.
+
+## Client and server
+
+The **client** is whoever makes the request. "Please give me the todo
+list page." That's usually a browser, sometimes a mobile app, rarely a
+terminal. One client, one person, one request at a time.
+
+The **server** is the machine that answers. It's a computer, always
+on, somewhere on the internet, waiting to be asked. One server, many
+clients at once — potentially millions.
+
+When you type `tene.sh` into your browser and hit enter:
+
+1. Your browser (client) asks the server at `tene.sh` for a page
+2. The server builds a response and sends it back
+3. Your browser paints it on screen
+
+That single round-trip, repeated a million times a day, is the whole
+web.
+
+## Frontend and backend
+
+These are two halves of what *you* write. The division is about
+audience more than technology.
+
+**Frontend** is every pixel the user sees. Buttons, layout, colors,
+animations, the text of the error message when they typo their email.
+It runs inside the user's browser. The main languages are HTML, CSS,
+JavaScript, and one of the JavaScript frameworks — React, Vue, or
+Svelte — plus a meta-framework on top, usually Next.js or Nuxt.
+
+**Backend** is everything the user *doesn't* see. Checking the
+password is right. Calculating the monthly invoice. Writing the row to
+the database. Sending the email. It runs on a server you control, not
+in the user's browser. Languages range widely — Node.js, Go, Python,
+Ruby — but the patterns are similar.
+
+The split matters because **the browser is hostile territory**. Any
+code you put in the frontend, any API key you ship to the browser,
+any database query you "temporarily" run from client-side code — a
+curious user can see all of it in 10 seconds with Chrome DevTools.
+Anything sensitive belongs on the backend.
+
+## The database
+
+If the backend is the kitchen, the database is the fridge. It's where
+data lives between requests.
+
+A **relational database** (SQL) stores data in tables, like a very
+fast spreadsheet that never corrupts and handles a million users at
+once. Columns have types. Relationships between tables are explicit.
+PostgreSQL, MySQL, and SQLite are the three names you'll hear most.
+
+A **document database** (NoSQL) stores data in flexible, nested
+documents — closer to JSON than to Excel. MongoDB is the famous one;
+DynamoDB and Firestore are the cloud-native equivalents.
+
+For a first app, pick SQLite or PostgreSQL. They're well-documented,
+cheap, boring in the good way, and AI coding assistants produce
+correct SQL for them out of the box. Exotic databases are a choice
+for version 2.
+
+## File storage
+
+Databases are bad at big files. A 40 KB profile is fine to store in a
+user row; a 4 MB profile photo is not. Binary files (images, videos,
+PDFs) go into **object storage**, separate from the database.
+
+AWS S3 is the original. Cloudflare R2, Backblaze B2, Google Cloud
+Storage, Azure Blob Storage — all the same idea: you get a bucket,
+you upload files to paths inside it, you get back URLs. Your backend
+saves the URL in the database; the user's browser fetches the file
+directly from the storage service.
+
+A critical detail for later: every one of these services requires an
+**access key** to write to your bucket. That key must never end up in
+the frontend. Never. This is where secrets management starts to
+matter.
+
+## Network and HTTPS
+
+HTTP is the protocol of the web. Browser asks, server replies, in
+plain text over the internet. The problem: anything in plain text can
+be read by anyone in the middle — your Wi-Fi router, your ISP, any
+malicious network along the way.
+
+HTTPS is HTTP wrapped in encryption. The `S` is for Secure. When your
+browser shows the padlock icon, you're on HTTPS. The encryption is
+cryptographically strong (TLS 1.3, usually) and, for the purposes of
+someone sniffing the Wi-Fi, unreadable.
+
+Two rules for 2026:
+
+1. **Everything is HTTPS**. Browsers now warn users about non-HTTPS
+   sites. Search engines penalize them. There is no excuse; Let's
+   Encrypt provides free certificates, and every deploy platform
+   (Vercel, Netlify, Fly, Railway) turns on HTTPS automatically.
+2. **The URL encryption doesn't protect the secret on your server**.
+   Anyone who breaks into your server reads your secrets directly,
+   TLS or not. HTTPS protects the wire, not the fridge.
+
+You also need a **domain name** — the human-readable address. A
+**DNS** record translates `tene.sh` into an IP address like
+`76.76.21.21`. Registrars (Namecheap, Cloudflare, Porkbun) sell
+domains by the year; DNS is usually handled by your deploy platform
+or Cloudflare.
+
+## Where the HTML comes from: CSR vs SSR
+
+One frontend detail that confuses newcomers. There are two ways to
+build the HTML the browser sees:
+
+- **CSR (Client-Side Rendering)**: Server ships a mostly-empty HTML
+  plus a big JavaScript bundle. Browser runs the JS, which builds the
+  page in memory. Fast to navigate between pages; slow on first load;
+  bad for SEO unless you add more machinery.
+- **SSR (Server-Side Rendering)**: Server builds the HTML ahead of
+  time and ships it complete. Browser paints it immediately. Fast
+  first load; good SEO; slightly more server work per request.
+
+Next.js and Nuxt default to a **hybrid**: SSR for the first page
+load, CSR for subsequent navigation. That's usually what you want.
+For a pure marketing site or blog, static generation (SSG — pre-build
+all pages to files) is even faster.
+
+## Infrastructure
+
+Everything above is code. **Infrastructure** is the hardware and
+configuration that runs it. You rarely touch it directly anymore, but
+it's what you're paying for.
+
+The modern default is **cloud infrastructure**: you don't buy
+servers, you rent capacity from AWS, Google Cloud, or Azure. Even
+better, you use a **platform** on top of the cloud — Vercel, Netlify,
+Fly.io, Railway — that hides the infrastructure almost entirely.
+You push code; the platform figures out where to run it.
+
+For a first deploy, use a platform. The moment you're doing something
+very custom (running a specific database engine, GPU workloads, or
+multi-region failover), you drop down to the cloud directly. Most
+apps never need to.
+
+## Deployment
+
+Deployment is the act of taking code from your laptop and making it
+live on the internet. The modern flow looks like this:
+
+1. You write code locally, commit it to **Git** (version control).
+2. You push the commits to **GitHub** (or GitLab, or similar).
+3. Your deploy platform is watching your GitHub repository.
+4. It sees a new commit, runs a **build** (compiles, bundles, minifies),
+   and copies the output to its servers.
+5. It swaps your new version in, users seamlessly start hitting the
+   new code.
+
+Three environments are common:
+
+- **Development**: your laptop. Breaks allowed.
+- **Staging**: a copy of production that your team can test against
+  before shipping. Breaks occasionally.
+- **Production**: the real one. Real users, real money, no breaks.
+
+A healthy deploy workflow: push to a branch → automatic staging
+deploy → eyeball it → merge to `main` → automatic production deploy.
+
+## The Vercel shortcut
+
+Vercel is worth a separate mention because it turns the whole deploy
+chapter into three clicks. Push your code to GitHub, connect the repo
+to Vercel, merge to `main` — live on the internet, HTTPS included,
+global CDN included.
+
+For Next.js / React apps, it's the path of least resistance. For more
+complex backends (long-running servers, GPU workloads, big database
+migrations), Vercel is the wrong answer and Fly.io or Railway or a
+proper AWS setup are better. Use the tool that fits the shape of your
+app, not the most-hyped one.
+
+## The security gap every vibe coder hits
+
+Here is the paragraph most "deploy your first app" tutorials omit.
+
+Your app almost certainly reads environment variables from a `.env`
+file: `STRIPE_KEY=sk_live_...`, `OPENAI_API_KEY=sk-...`,
+`DATABASE_URL=postgres://...`. That file sits at the root of your
+project, in plaintext.
+
+Three things then happen that tutorials don't warn you about:
+
+1. **Your AI coding assistant reads it.** Claude Code, Cursor,
+   Windsurf, Copilot — all of them index project files as context.
+   `.env` is a file in the project; it gets included. Your API keys
+   end up inside the model's context window on every request, and
+   sometimes in conversation logs.
+2. **You accidentally commit it.** One `git add .` at 2 a.m., a
+   misread `.gitignore`, a forgotten path — the keys are now on
+   GitHub. GitHub's secret scanner catches most but not all.
+3. **You paste the key somewhere while debugging.** A Discord
+   channel, a Stack Overflow question, a screenshot in a
+   presentation. It takes one slip.
+
+Any one of the three is enough for an attacker to start billing your
+credit card against your OpenAI account.
+
+**The structural fix** is to never let the plaintext `.env` exist on
+disk in the first place. Encrypt the secrets at rest, decrypt them in
+memory only, and pass them to your app via environment variables at
+runtime. That's the pattern
+[tene](https://github.com/tomo-kay/tene) implements:
+
+```bash
+# 1. Install once
+curl -sSfL https://tene.sh/install.sh | sh
+
+# 2. Import your existing .env, then delete the plaintext
+tene import .env
+rm .env
+
+# 3. Run your app — secrets injected as env vars at runtime
+tene run -- npm start
+```
+
+Your code continues to read `process.env.STRIPE_KEY` exactly as
+before. The difference: the key never sits on disk in plaintext, the
+AI agent can't index it, an accidental `git add` can't leak it. For
+the full threat model, see
+[*Your .env is not a secret. AI can read it.*](/blog/ai-reads-env).
+
+## The sensible first stack for a vibe coder in 2026
+
+If you're building your first real app, not a tutorial exercise, here
+is the defensible path:
+
+- **Frontend framework**: Next.js. Huge ecosystem, best AI support.
+- **Database**: Postgres via Supabase or Neon. Free tier, managed
+  backups, scales far enough.
+- **File storage**: Supabase Storage if already on Supabase; Cloudflare
+  R2 if you want zero egress fees.
+- **Auth**: Clerk or Auth.js (NextAuth). Don't roll your own.
+- **Deploy**: Vercel for the frontend. The managed database lives on
+  Supabase / Neon's side.
+- **Secret management**: [tene](https://github.com/tomo-kay/tene) for
+  local dev (keeps keys out of your AI agent's context) + Vercel's
+  environment-variable UI for production.
+- **Domain**: Cloudflare. Cheap, fast DNS, free HTTPS on top.
+
+That stack gets you to ten paying customers without reorganizing.
+Past that, you'll know what's breaking because you'll feel it.
+
+## What "production-ready" actually means
+
+A last piece of framing. When people say an app is
+"production-ready," they usually mean it handles these five things
+without the founder being paged:
+
+1. **Availability**: survives individual server failures
+2. **Observability**: when something breaks, you can tell *what*
+3. **Security**: secrets stay secret, users stay isolated from each
+   other
+4. **Cost**: the bill doesn't surprise you at 3 a.m.
+5. **Recoverability**: if the database melts, you can restore
+
+Vibe coding excels at getting to the demo. The gap between demo and
+production is learning each of those five. The good news: every one
+has platform-level answers in 2026. The better news: learning them
+once applies to every future project.
+
+## Summary — the shortest usable mental model
+
+- **Client / server**: one asks, one answers. Always.
+- **Frontend / backend**: seen / unseen halves of your app. Hostile
+  browser, trusted server.
+- **Database / file storage**: structured data vs big blobs. Different
+  tools.
+- **HTTPS**: encryption on the wire. Always. Free.
+- **CSR / SSR**: where HTML gets built. Next.js does both.
+- **Infrastructure**: the hardware you rent. Use a platform, not raw
+  cloud, until you can't.
+- **Deployment**: git push, wait, URL updates. Vercel, Fly, Railway,
+  or raw cloud.
+- **Secrets**: the one thing tutorials lie about. Keep them off disk
+  and out of the AI agent's context from day one — that's what
+  [tene](https://github.com/tomo-kay/tene) is for.
+
+Related reading:
+- [Your .env is not a secret. AI can read it.](/blog/ai-reads-env)
+- [Migrating from .env to an encrypted vault in 60 seconds](/blog/migrate-env-60s)
+- [Claude Code + API keys: the safe workflow](/blog/claude-code-safe-api-keys)

--- a/apps/web/content/blog/xchacha20-for-devs.mdx
+++ b/apps/web/content/blog/xchacha20-for-devs.mdx
@@ -4,7 +4,8 @@ title: "XChaCha20-Poly1305 for developers: why it is the right choice for local 
 description: "A practical explanation of XChaCha20-Poly1305 and why tene picked it over AES-GCM for a local-first secret vault. No PhD required."
 publishedAt: "2026-04-21"
 updatedAt: "2026-04-21"
-tags: ["security", "cryptography", "go", "architecture"]
+category: engineering
+tags: ["cryptography", "architecture", "security", "tene"]
 author: "tomo-kay"
 cover: "/og-image.png"
 canonicalUrl: "https://tene.sh/blog/xchacha20-for-devs"

--- a/apps/web/src/app/blog/category/[category]/page.tsx
+++ b/apps/web/src/app/blog/category/[category]/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Nav } from "@/components/nav";
+import { Footer } from "@/components/footer";
+import { InteractiveGrid } from "@/components/interactive-grid";
+import { PostCard } from "@/components/blog/post-card";
+import { BlogIndexJsonLd } from "@/components/seo/blog-index-jsonld";
+import { getAllCategories, getPostsByCategory } from "@/lib/blog";
+import {
+  CATEGORY_DESCRIPTIONS,
+  getCategoryLabel,
+  isValidCategory,
+  type CategoryKey,
+} from "@/lib/tags";
+
+export const dynamic = "error";
+
+type Params = { category: string };
+
+export function generateStaticParams(): Params[] {
+  // All 4 categories are generated even with count=0 — empty categories show
+  // a "Coming soon" placeholder rather than 404, so the taxonomy is always
+  // discoverable in navigation.
+  return getAllCategories().map(({ category }) => ({ category }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { category } = await params;
+  if (!isValidCategory(category)) return {};
+  const label = getCategoryLabel(category);
+  const description = CATEGORY_DESCRIPTIONS[category as CategoryKey];
+  const canonical = `https://tene.sh/blog/category/${category}`;
+
+  return {
+    title: `${label} — tene Tech Blog`,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: `${label} — tene Tech Blog`,
+      description,
+      url: canonical,
+      siteName: "Tene",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${label} — tene Tech Blog`,
+      description,
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function CategoryPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { category } = await params;
+  if (!isValidCategory(category)) notFound();
+
+  const posts = getPostsByCategory(category);
+  const label = getCategoryLabel(category);
+  const description = CATEGORY_DESCRIPTIONS[category as CategoryKey];
+
+  return (
+    <>
+      {/* CollectionPage + BreadcrumbList schema (reuses blog index json-ld) */}
+      <BlogIndexJsonLd posts={posts} category={category} />
+
+      <InteractiveGrid />
+      <div className="dot-grid-fixed sm:hidden" />
+
+      <Nav />
+      <main className="relative z-10">
+        <section className="px-4 pt-28 pb-8 sm:px-6">
+          <div className="mx-auto max-w-4xl text-center">
+            <nav aria-label="Breadcrumb" className="text-sm text-muted">
+              <Link
+                href="/blog"
+                className="underline underline-offset-4 hover:text-foreground"
+              >
+                Blog
+              </Link>
+              <span className="mx-2 opacity-60">/</span>
+              <span className="text-foreground">{label}</span>
+            </nav>
+            <h1 className="mt-3 text-3xl font-bold sm:text-4xl md:text-5xl">
+              {label}
+            </h1>
+            <p className="mx-auto mt-4 max-w-2xl text-muted">{description}</p>
+            <p className="mt-4 text-sm text-muted">
+              {posts.length} article{posts.length === 1 ? "" : "s"}
+            </p>
+          </div>
+        </section>
+
+        <section className="px-4 pb-16 sm:px-6">
+          {posts.length === 0 ? (
+            <div className="mx-auto max-w-xl rounded-lg border border-border bg-surface/50 p-8 text-center text-muted">
+              <p className="font-medium text-foreground">Coming soon.</p>
+              <p className="mt-2 text-sm">
+                No articles in <span className="text-accent">{label}</span> yet.
+                Check back soon or{" "}
+                <Link
+                  href="/blog"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  browse other categories
+                </Link>
+                .
+              </p>
+            </div>
+          ) : (
+            <ul className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
+              {posts.map((p) => (
+                <li key={p.slug}>
+                  <PostCard post={p} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,12 +1,15 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { InteractiveGrid } from "@/components/interactive-grid";
 import { PostCard } from "@/components/blog/post-card";
-import { TagCloud } from "@/components/blog/tag-cloud";
 import { RssLink } from "@/components/blog/rss-link";
+import { CategoryPills } from "@/components/blog/category-pills";
+import { TagFilter } from "@/components/blog/tag-filter";
+import { BlogIndexClient } from "@/components/blog/blog-index-client";
 import { BlogIndexJsonLd } from "@/components/seo/blog-index-jsonld";
-import { getAllPosts, getAllTags } from "@/lib/blog";
+import { getAllCategories, getAllPosts, getAllTags } from "@/lib/blog";
 
 export const metadata: Metadata = {
   title: "Tech Blog — Tene",
@@ -50,6 +53,22 @@ export const metadata: Metadata = {
 export default function BlogIndex() {
   const posts = getAllPosts();
   const tags = getAllTags();
+  const categories = getAllCategories();
+
+  // Plain JSON payload for client component — BlogPostMeta minus any
+  // non-serialisable fields (there are none today).
+  const postsForClient = posts.map((p) => ({
+    slug: p.slug,
+    title: p.title,
+    description: p.description,
+    publishedAt: p.publishedAt,
+    updatedAt: p.updatedAt,
+    category: p.category,
+    tags: p.tags,
+    author: p.author,
+    readingMinutes: p.readingMinutes,
+    wordCount: p.wordCount,
+  }));
 
   return (
     <>
@@ -61,14 +80,13 @@ export default function BlogIndex() {
 
       <Nav />
       <main className="relative z-10">
-        <section className="px-4 pt-28 pb-8 sm:px-6">
+        <section className="px-4 pt-28 pb-6 sm:px-6">
           <div className="mx-auto max-w-4xl text-center">
             <h1 className="text-3xl font-bold leading-tight tracking-tight sm:text-4xl md:text-5xl">
               tene Tech Blog
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-base text-muted leading-relaxed sm:text-lg">
-              AI-safe secrets · Vibe coding · Developer security · Local-first
-              infrastructure
+              Tools · Engineering · Vibe Coding · Philosophy
             </p>
 
             <div className="mt-6 flex justify-center">
@@ -77,9 +95,22 @@ export default function BlogIndex() {
           </div>
         </section>
 
+        {categories.length > 0 && (
+          <section className="px-4 pb-6 sm:px-6">
+            <CategoryPills categories={categories} />
+          </section>
+        )}
+
         {tags.length > 0 && (
-          <section className="px-4 pb-12 sm:px-6">
-            <TagCloud tags={tags} />
+          <section className="px-4 pb-8 sm:px-6">
+            {/* useSearchParams suspense boundary (Next.js 15 requirement). */}
+            <Suspense
+              fallback={
+                <div className="mx-auto h-12 max-w-4xl rounded-lg border border-border/50 bg-surface/30" />
+              }
+            >
+              <TagFilter allTags={tags} />
+            </Suspense>
           </section>
         )}
 
@@ -89,13 +120,19 @@ export default function BlogIndex() {
               No articles published yet. Check back soon.
             </div>
           ) : (
-            <ul className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
-              {posts.map((post) => (
-                <li key={post.slug}>
-                  <PostCard post={post} />
-                </li>
-              ))}
-            </ul>
+            <Suspense
+              fallback={
+                <ul className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
+                  {postsForClient.map((post) => (
+                    <li key={post.slug}>
+                      <PostCard post={post} />
+                    </li>
+                  ))}
+                </ul>
+              }
+            >
+              <BlogIndexClient posts={postsForClient} />
+            </Suspense>
           )}
         </section>
       </main>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Comparison } from "@/components/comparison";
 import { HowItWorks } from "@/components/how-it-works";
 import { Security } from "@/components/security";
 import { Trust } from "@/components/trust";
+import { BlogPreview } from "@/components/blog-preview";
 import { CTA } from "@/components/cta";
 import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
@@ -28,6 +29,7 @@ export default function Home() {
         <Trust />
         <Comparison />
         {/* <Pricing /> */}
+        <BlogPreview />
         <FAQ />
         <CTA />
       </main>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,11 +1,11 @@
 import type { MetadataRoute } from "next";
 import { comparisons } from "@/data/comparisons";
-import { getAllPosts, getAllTags } from "@/lib/blog";
+import { getAllCategories, getAllPosts, getAllTags } from "@/lib/blog";
 
 // Next.js generates /sitemap.xml from this file at build time (force-static
 // route). Includes the home page, the /vs index, every /vs/{slug} page, and
-// the /blog + /blog/{slug} + /blog/tag/{tag} + /blog/rss.xml.
-// Submit to Google Search Console via "Add sitemap".
+// the /blog + /blog/{slug} + /blog/tag/{tag} + /blog/category/{cat} +
+// /blog/rss.xml. Submit to Google Search Console via "Add sitemap".
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://tene.sh";
   const lastModified = new Date().toISOString();
@@ -31,6 +31,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "monthly",
     priority: 0.5,
   }));
+
+  // 4 category hub pages — always present, even with 0 posts (empty
+  // categories render a "Coming soon" placeholder for taxonomy discovery).
+  const blogCategoryUrls: MetadataRoute.Sitemap = getAllCategories().map(
+    ({ category }) => ({
+      url: `${base}/blog/category/${category}`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    }),
+  );
 
   return [
     {
@@ -65,6 +76,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     ...blogPostUrls,
+    ...blogCategoryUrls,
     ...blogTagUrls,
   ];
 }

--- a/apps/web/src/components/blog-preview.tsx
+++ b/apps/web/src/components/blog-preview.tsx
@@ -1,0 +1,68 @@
+// Landing page blog preview — one latest post per category (max 4) so the
+// home page always showcases the 2-layer taxonomy. Categories with zero
+// posts are skipped rather than shown as "Coming soon" cards, keeping the
+// landing density on actual content.
+import Link from "next/link";
+import { PostCard } from "@/components/blog/post-card";
+import { getAllCategories, getPostsByCategory } from "@/lib/blog";
+
+export function BlogPreview() {
+  const categories = getAllCategories();
+
+  // Pick the latest post per category (if any).
+  const highlights = categories
+    .map(({ category }) => {
+      const posts = getPostsByCategory(category);
+      return posts.length > 0 ? posts[0] : null;
+    })
+    .filter((p): p is NonNullable<typeof p> => p !== null);
+
+  if (highlights.length === 0) return null;
+
+  return (
+    <section className="px-4 py-20 sm:px-6">
+      <div className="mx-auto max-w-5xl">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            From the Blog
+          </h2>
+          <p className="mt-3 text-muted">
+            Tools · Engineering · Vibe Coding · Philosophy
+          </p>
+        </div>
+
+        <ul className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {highlights.map((post) => (
+            <li key={post.slug}>
+              <PostCard post={post} />
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-8 flex justify-center">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-surface/60 px-4 py-2 text-sm text-muted backdrop-blur-sm transition-colors hover:border-accent/40 hover:text-foreground"
+          >
+            Browse all posts
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <line x1="5" y1="12" x2="19" y2="12" />
+              <polyline points="12 5 19 12 12 19" />
+            </svg>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/blog/blog-index-client.tsx
+++ b/apps/web/src/components/blog/blog-index-client.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+// Client component that reads ?tags=a,b from the URL and filters the SSR'd
+// post list in-place. Renders the full list initially so users without JS
+// still see all articles. Kept separate from page.tsx to keep the server
+// component pure (no client hooks).
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { PostCard } from "@/components/blog/post-card";
+import type { BlogPostMeta } from "@/lib/blog";
+
+type Props = {
+  posts: BlogPostMeta[];
+};
+
+function parseSelected(raw: string | null): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+export function BlogIndexClient({ posts }: Props) {
+  const searchParams = useSearchParams();
+  const selected = useMemo(
+    () => parseSelected(searchParams.get("tags")),
+    [searchParams],
+  );
+
+  const filtered = useMemo(() => {
+    if (selected.size === 0) return posts;
+    // AND mode: a post matches only if it contains every selected tag.
+    return posts.filter((p) =>
+      [...selected].every((t) => p.tags.includes(t as never)),
+    );
+  }, [posts, selected]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="mx-auto max-w-xl rounded-lg border border-border bg-surface/50 p-8 text-center text-muted">
+        <p className="font-medium text-foreground">No articles match.</p>
+        <p className="mt-2 text-sm">
+          Try removing a tag filter, or browse{" "}
+          <a
+            href="/blog"
+            className="underline underline-offset-4 hover:text-foreground"
+          >
+            all articles
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
+      {filtered.map((post) => (
+        <li key={post.slug}>
+          <PostCard post={post} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/blog/category-badge.tsx
+++ b/apps/web/src/components/blog/category-badge.tsx
@@ -1,0 +1,43 @@
+// Small category badge for post cards and post headers. Color scheme
+// intentionally uses Tailwind's named colors with low-opacity surfaces so
+// the badge reads as a soft status pill, not a button.
+import Link from "next/link";
+import { getCategoryLabel, type CategoryKey } from "@/lib/tags";
+
+type Props = {
+  category: CategoryKey;
+  size?: "sm" | "md";
+  asLink?: boolean; // when true, renders as Link to /blog/category/{slug}
+};
+
+const COLOR_BY_CATEGORY: Record<CategoryKey, string> = {
+  tools: "bg-blue-500/10 text-blue-300 border-blue-500/30",
+  engineering: "bg-purple-500/10 text-purple-300 border-purple-500/30",
+  "vibe-coding": "bg-emerald-500/10 text-emerald-300 border-emerald-500/30",
+  philosophy: "bg-amber-500/10 text-amber-300 border-amber-500/30",
+};
+
+export function CategoryBadge({
+  category,
+  size = "sm",
+  asLink = false,
+}: Props) {
+  const label = getCategoryLabel(category);
+  const colorClass = COLOR_BY_CATEGORY[category];
+  const sizeClass =
+    size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm";
+  const base = `inline-flex items-center rounded border font-medium ${sizeClass} ${colorClass}`;
+
+  if (asLink) {
+    return (
+      <Link
+        href={`/blog/category/${category}`}
+        className={`${base} hover:opacity-80 transition-opacity`}
+      >
+        {label}
+      </Link>
+    );
+  }
+
+  return <span className={base}>{label}</span>;
+}

--- a/apps/web/src/components/blog/category-pills.tsx
+++ b/apps/web/src/components/blog/category-pills.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+// Category pills shown at the top of /blog index. Primary navigation axis
+// for the 2-layer taxonomy (category + tag). See blog-content.md §2.
+import Link from "next/link";
+import { track } from "@/lib/track";
+import type { CategoryKey } from "@/lib/tags";
+
+type CategoryEntry = {
+  category: CategoryKey;
+  count: number;
+  label: string;
+};
+
+type Props = {
+  categories: CategoryEntry[];
+  activeCategory?: CategoryKey | null;
+};
+
+export function CategoryPills({ categories, activeCategory }: Props) {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-wrap items-center justify-center gap-2">
+      {categories.map(({ category, count, label }) => {
+        const isActive = activeCategory === category;
+        const stateClass = isActive
+          ? "border-accent bg-accent/10 text-foreground"
+          : "border-border bg-surface/60 text-muted hover:border-accent/40 hover:text-foreground";
+        return (
+          <Link
+            key={category}
+            href={`/blog/category/${category}`}
+            aria-current={isActive ? "page" : undefined}
+            onClick={() =>
+              track("blog_category_filter", {
+                category,
+                from: isActive ? "active" : "index",
+              })
+            }
+            className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm backdrop-blur-sm transition-colors ${stateClass}`}
+          >
+            {label}
+            <span className="text-xs opacity-60">({count})</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/post-card.tsx
+++ b/apps/web/src/components/blog/post-card.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { GlowCard } from "@/components/glow-card";
-import { TagChip } from "@/components/blog/tag-chip";
+import { CategoryBadge } from "@/components/blog/category-badge";
 import type { BlogPostMeta } from "@/lib/blog";
 
 type Props = {
@@ -20,15 +20,18 @@ function formatDate(iso: string): string {
 }
 
 export function PostCard({ post }: Props) {
+  const visibleTags = post.tags.slice(0, 2);
+  const hiddenTagCount = post.tags.length - visibleTags.length;
+
   return (
     <GlowCard className="h-full rounded-lg border border-border bg-surface/80 backdrop-blur-sm transition-colors hover:border-accent/40">
       <Link href={`/blog/${post.slug}`} className="block h-full p-6">
-        <time
-          className="text-xs text-muted"
-          dateTime={post.publishedAt}
-        >
-          {formatDate(post.publishedAt)} · {post.readingMinutes} min read
-        </time>
+        <div className="flex flex-wrap items-center gap-2">
+          <CategoryBadge category={post.category} />
+          <time className="text-xs text-muted" dateTime={post.publishedAt}>
+            {formatDate(post.publishedAt)} · {post.readingMinutes} min read
+          </time>
+        </div>
         <h3 className="mt-3 text-lg font-semibold leading-tight">
           {post.title}
         </h3>
@@ -36,8 +39,8 @@ export function PostCard({ post }: Props) {
           {post.description}
         </p>
         {post.tags.length > 0 && (
-          <div className="mt-4 flex flex-wrap gap-1.5">
-            {post.tags.slice(0, 3).map((tag) => (
+          <div className="mt-4 flex flex-wrap items-center gap-1.5">
+            {visibleTags.map((tag) => (
               <span
                 key={tag}
                 className="inline-flex items-center gap-0.5 rounded-full border border-border/60 px-2 py-0.5 text-xs text-muted"
@@ -46,6 +49,9 @@ export function PostCard({ post }: Props) {
                 {tag}
               </span>
             ))}
+            {hiddenTagCount > 0 && (
+              <span className="text-xs text-muted">+{hiddenTagCount} more</span>
+            )}
           </div>
         )}
       </Link>

--- a/apps/web/src/components/blog/post-hero.tsx
+++ b/apps/web/src/components/blog/post-hero.tsx
@@ -1,4 +1,5 @@
 import { TagChip } from "@/components/blog/tag-chip";
+import { CategoryBadge } from "@/components/blog/category-badge";
 import type { BlogPostMeta } from "@/lib/blog";
 
 type Props = {
@@ -26,6 +27,7 @@ export function PostHero({ meta }: Props) {
     <header className="px-4 pt-4 pb-8 sm:px-6">
       <div className="mx-auto max-w-3xl">
         <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
+          <CategoryBadge category={meta.category} asLink />
           <time dateTime={meta.publishedAt}>{formatDate(meta.publishedAt)}</time>
           <span aria-hidden="true">·</span>
           <span>{meta.readingMinutes} min read</span>

--- a/apps/web/src/components/blog/tag-filter.tsx
+++ b/apps/web/src/components/blog/tag-filter.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+// Instagram-style tag filter on /blog index. Client-only filtering via URL
+// query param (?tags=a,b). AND mode: a post is shown only if it carries
+// ALL selected tags. Collapsed by default to avoid clutter.
+import { useCallback, useMemo, useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getTagLabel, type TagKey } from "@/lib/tags";
+import { track } from "@/lib/track";
+
+type TagEntry = { tag: string; count: number };
+
+type Props = {
+  allTags: TagEntry[]; // sorted by count desc
+  topN?: number; // how many to show before "Show all"
+};
+
+function parseTagsParam(raw: string | null): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+export function TagFilter({ allTags, topN = 6 }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const [, startTransition] = useTransition();
+
+  const selected = useMemo(
+    () => parseTagsParam(searchParams.get("tags")),
+    [searchParams],
+  );
+
+  const filteredTags = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return allTags;
+    return allTags.filter(
+      ({ tag }) =>
+        tag.toLowerCase().includes(q) ||
+        getTagLabel(tag).toLowerCase().includes(q),
+    );
+  }, [allTags, search]);
+
+  const visibleTags = useMemo(() => {
+    if (search.trim()) return filteredTags; // search overrides topN
+    if (showAll) return filteredTags;
+    return filteredTags.slice(0, topN);
+  }, [filteredTags, showAll, search, topN]);
+
+  const updateUrl = useCallback(
+    (nextSelected: Set<string>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (nextSelected.size === 0) {
+        params.delete("tags");
+      } else {
+        params.set("tags", [...nextSelected].sort().join(","));
+      }
+      const query = params.toString();
+      startTransition(() => {
+        router.replace(query ? `/blog?${query}` : "/blog", { scroll: false });
+      });
+    },
+    [router, searchParams],
+  );
+
+  const toggle = (tag: string) => {
+    const next = new Set(selected);
+    if (next.has(tag)) {
+      next.delete(tag);
+      track("blog_tag_filter", { tag, action: "remove", from: "filter" });
+    } else {
+      next.add(tag);
+      track("blog_tag_filter", { tag, action: "add", from: "filter" });
+    }
+    updateUrl(next);
+  };
+
+  const clearAll = () => {
+    track("blog_tag_filter", { action: "clear_all", from: "filter" });
+    updateUrl(new Set());
+  };
+
+  const hasActive = selected.size > 0;
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <details
+        open={open || hasActive}
+        onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}
+        className="rounded-lg border border-border bg-surface/40 backdrop-blur-sm"
+      >
+        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-medium text-muted hover:text-foreground">
+          <span className="flex items-center gap-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+            </svg>
+            Filter by topic{" "}
+            {hasActive && (
+              <span className="rounded-full bg-accent/20 px-2 py-0.5 text-xs text-accent">
+                {selected.size}
+              </span>
+            )}
+          </span>
+          <span className="text-xs opacity-60">
+            {open || hasActive ? "Close" : "Open"}
+          </span>
+        </summary>
+
+        <div className="border-t border-border/60 p-4">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              inputMode="search"
+              placeholder="Search topics..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-accent focus:outline-none"
+              aria-label="Search tags"
+            />
+            {hasActive && (
+              <button
+                onClick={clearAll}
+                type="button"
+                className="shrink-0 rounded-md border border-border px-3 py-2 text-sm text-muted hover:border-accent/40 hover:text-foreground"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          {visibleTags.length === 0 ? (
+            <p className="mt-4 text-center text-sm text-muted">
+              No topics match &quot;{search}&quot;.
+            </p>
+          ) : (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {visibleTags.map(({ tag, count }) => {
+                const isSelected = selected.has(tag);
+                const stateClass = isSelected
+                  ? "border-accent bg-accent/10 text-foreground"
+                  : "border-border bg-surface/60 text-muted hover:border-accent/40 hover:text-foreground";
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggle(tag)}
+                    aria-pressed={isSelected}
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors ${stateClass}`}
+                  >
+                    <span className="text-accent">#</span>
+                    {getTagLabel(tag)}
+                    <span className="text-xs opacity-60">({count})</span>
+                  </button>
+                );
+              })}
+              {!showAll &&
+                !search.trim() &&
+                filteredTags.length > topN && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAll(true)}
+                    className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1.5 text-sm text-muted hover:border-accent/40 hover:text-foreground"
+                  >
+                    Show all ({filteredTags.length})
+                  </button>
+                )}
+            </div>
+          )}
+
+          {hasActive && (
+            <p className="mt-3 text-xs text-muted">
+              Showing posts with{" "}
+              <span className="text-foreground">all</span> selected topics.
+            </p>
+          )}
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/apps/web/src/components/seo/blog-index-jsonld.tsx
+++ b/apps/web/src/components/seo/blog-index-jsonld.tsx
@@ -1,31 +1,56 @@
 // Design Ref: blog-seo-enhancements §2.2 — G2 CollectionPage/Blog schema for
-// /blog and /blog/tag/[tag]. AI search engines use this to identify the
-// section as a blog and enumerate articles for potential citation.
+// /blog, /blog/tag/[tag], and /blog/category/[category]. AI search engines use
+// this to identify the section as a blog and enumerate articles for citation.
 import type { BlogPostMeta } from "@/lib/blog";
-import { getTagLabel } from "@/lib/tags";
+import { getCategoryLabel, getTagLabel } from "@/lib/tags";
 
 type Props = {
   posts: BlogPostMeta[];
-  // undefined = main /blog index; string = /blog/tag/{tag} view
+  // undefined = main /blog index
+  // tag set = /blog/tag/{tag} view
+  // category set = /blog/category/{category} view
   tag?: string;
+  category?: string;
 };
 
-export function BlogIndexJsonLd({ posts, tag }: Props) {
+export function BlogIndexJsonLd({ posts, tag, category }: Props) {
   const isTagPage = !!tag;
-  const canonical = isTagPage
-    ? `https://tene.sh/blog/tag/${tag}`
-    : "https://tene.sh/blog";
-  const label = isTagPage ? getTagLabel(tag!) : "tene Tech Blog";
+  const isCategoryPage = !!category;
+
+  let canonical: string;
+  let label: string;
+  let breadcrumbLabel: string;
+  if (isTagPage) {
+    canonical = `https://tene.sh/blog/tag/${tag}`;
+    label = getTagLabel(tag!);
+    breadcrumbLabel = `#${label}`;
+  } else if (isCategoryPage) {
+    canonical = `https://tene.sh/blog/category/${category}`;
+    label = getCategoryLabel(category!);
+    breadcrumbLabel = label;
+  } else {
+    canonical = "https://tene.sh/blog";
+    label = "tene Tech Blog";
+    breadcrumbLabel = "Blog";
+  }
+
+  const isFilteredView = isTagPage || isCategoryPage;
 
   const ld = {
     "@context": "https://schema.org",
     "@graph": [
       {
-        "@type": isTagPage ? "CollectionPage" : "Blog",
-        name: isTagPage ? `${label} articles` : "tene Tech Blog",
+        "@type": isFilteredView ? "CollectionPage" : "Blog",
+        name: isTagPage
+          ? `${label} articles`
+          : isCategoryPage
+            ? `${label} — tene Tech Blog`
+            : "tene Tech Blog",
         description: isTagPage
           ? `Articles tagged ${label} from the tene Tech Blog.`
-          : "AI-safe secrets · Vibe coding · Developer security · Local-first infrastructure",
+          : isCategoryPage
+            ? `Articles in the ${label} category of the tene Tech Blog.`
+            : "AI-safe secrets · Vibe coding · Developer security · Local-first infrastructure",
         url: canonical,
         inLanguage: "en-US",
         publisher: {
@@ -44,6 +69,7 @@ export function BlogIndexJsonLd({ posts, tag }: Props) {
           url: `https://tene.sh/blog/${p.slug}`,
           datePublished: p.publishedAt,
           dateModified: p.updatedAt ?? p.publishedAt,
+          articleSection: getCategoryLabel(p.category),
           keywords: p.tags.join(", "),
           author: {
             "@type": "Person",
@@ -51,10 +77,10 @@ export function BlogIndexJsonLd({ posts, tag }: Props) {
           },
         })),
       },
-      // BreadcrumbList: Home > Blog (> #tag)
+      // BreadcrumbList: Home > Blog (> filtered view)
       {
         "@type": "BreadcrumbList",
-        itemListElement: isTagPage
+        itemListElement: isFilteredView
           ? [
               {
                 "@type": "ListItem",
@@ -71,7 +97,7 @@ export function BlogIndexJsonLd({ posts, tag }: Props) {
               {
                 "@type": "ListItem",
                 position: 3,
-                name: `#${label}`,
+                name: breadcrumbLabel,
                 item: canonical,
               },
             ]

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -1,9 +1,18 @@
 // Design Ref: §2.2 T2-1 — Blog post registry. Reads from content/blog/*.mdx at
 // build time. No DB, no CMS — git is the source of truth. Plan D2, C-01.
+// Category+Tag taxonomy: docs/02-design/features/blog-categories-and-tooling.design.md
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
 import readingTimeLib from "reading-time";
+import {
+  CATEGORY_VOCABULARY,
+  isValidCategory,
+  isValidTag,
+  getCategoryLabel,
+  type CategoryKey,
+  type TagKey,
+} from "./tags";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "blog");
 
@@ -13,7 +22,8 @@ export type BlogPostFrontmatter = {
   description: string;
   publishedAt: string; // ISO 8601 (YYYY-MM-DD OK)
   updatedAt?: string;
-  tags: string[];
+  category: CategoryKey; // REQUIRED. See taxonomy design doc.
+  tags: TagKey[];
   author?: string; // default: "tomo-kay"
   cover?: string;
   canonicalUrl?: string; // default: https://tene.sh/blog/{slug}
@@ -51,13 +61,41 @@ function loadPost(slug: string): LoadedPost | null {
   const { data, content } = matter(raw);
   const rt = readingTimeLib(content);
 
+  // Category: required. Build fails fast if missing or invalid — stops a
+  // silently-wrong post from shipping to production.
+  const rawCategory = data.category as string | undefined;
+  if (!rawCategory) {
+    throw new Error(
+      `[blog] ${slug}.mdx: frontmatter 'category' is required. ` +
+        `Allowed: ${Object.keys(CATEGORY_VOCABULARY).join(", ")}`,
+    );
+  }
+  if (!isValidCategory(rawCategory)) {
+    throw new Error(
+      `[blog] ${slug}.mdx: invalid category '${rawCategory}'. ` +
+        `Allowed: ${Object.keys(CATEGORY_VOCABULARY).join(", ")}`,
+    );
+  }
+
+  // Tags: filter to valid vocabulary; warn in build log on unknowns.
+  const rawTags = (data.tags as string[]) ?? [];
+  const tags: TagKey[] = [];
+  for (const t of rawTags) {
+    if (isValidTag(t)) {
+      tags.push(t);
+    } else if (process.env.NODE_ENV !== "production") {
+      console.warn(`[blog] ${slug}.mdx: unknown tag '${t}' ignored`);
+    }
+  }
+
   const meta: BlogPostMeta = {
     slug: (data.slug as string) ?? slug,
     title: data.title as string,
     description: data.description as string,
     publishedAt: data.publishedAt as string,
     updatedAt: data.updatedAt as string | undefined,
-    tags: (data.tags as string[]) ?? [],
+    category: rawCategory,
+    tags,
     author: (data.author as string) ?? "tomo-kay",
     cover: data.cover as string | undefined,
     canonicalUrl:
@@ -130,5 +168,31 @@ export function getAllTags(): Array<{ tag: string; count: number }> {
 }
 
 export function getPostsByTag(tag: string): BlogPostMeta[] {
+  if (!isValidTag(tag)) return [];
   return getAllPosts().filter((p) => p.tags.includes(tag));
+}
+
+// ---------------------------------------------------------------------------
+// Categories — returns all 4 even with count=0 (empty categories remain
+// visible in navigation so readers see the full taxonomy).
+// ---------------------------------------------------------------------------
+export function getAllCategories(): Array<{
+  category: CategoryKey;
+  count: number;
+  label: string;
+}> {
+  const counts = new Map<string, number>();
+  for (const post of getAllPosts()) {
+    counts.set(post.category, (counts.get(post.category) ?? 0) + 1);
+  }
+  return (Object.keys(CATEGORY_VOCABULARY) as CategoryKey[]).map((cat) => ({
+    category: cat,
+    count: counts.get(cat) ?? 0,
+    label: getCategoryLabel(cat),
+  }));
+}
+
+export function getPostsByCategory(cat: string): BlogPostMeta[] {
+  if (!isValidCategory(cat)) return [];
+  return getAllPosts().filter((p) => p.category === cat);
 }

--- a/apps/web/src/lib/tags.ts
+++ b/apps/web/src/lib/tags.ts
@@ -1,16 +1,62 @@
-// Design Ref: §2.2 T2-2 — Fixed tag vocabulary to prevent fragmentation.
-// New tags require editing this file (PR review checkpoint). Plan D6.
+// Design Ref: §2.1 T2-2 — Fixed taxonomy (Category + Tag) to prevent
+// fragmentation. Both vocabularies are closed sets; new entries require a PR.
+// See: docs/02-design/features/blog-categories-and-tooling.design.md
+
+// ---------------------------------------------------------------------------
+// Categories — 1 required per post. Primary navigation axis on /blog.
+// ---------------------------------------------------------------------------
+export const CATEGORY_VOCABULARY = {
+  tools: "Tools",
+  engineering: "Engineering",
+  "vibe-coding": "Vibe Coding",
+  philosophy: "Philosophy",
+} as const;
+
+export type CategoryKey = keyof typeof CATEGORY_VOCABULARY;
+
+export function isValidCategory(cat: string): cat is CategoryKey {
+  return cat in CATEGORY_VOCABULARY;
+}
+
+export function getCategoryLabel(cat: string): string {
+  return (CATEGORY_VOCABULARY as Record<string, string>)[cat] ?? cat;
+}
+
+export const CATEGORY_DESCRIPTIONS: Record<CategoryKey, string> = {
+  tools:
+    "Posts about tene, bkit, and the wider ADK family of developer tools.",
+  engineering:
+    "Engineering concepts, system design, cryptography, CLI architecture.",
+  "vibe-coding":
+    "AI-assisted development in practice — editor setups, agent workflows.",
+  philosophy:
+    "Essays on the AI era, solo-founder journey, and the craft of software.",
+};
+
+// ---------------------------------------------------------------------------
+// Tags — 2–4 per post. Cross-cutting sub-topics. Organised into four axes
+// mentally, but flat at the schema level.
+// ---------------------------------------------------------------------------
 export const TAG_VOCABULARY = {
+  // Products
+  tene: "tene",
+  bkit: "bkit",
+  // Technical domain
   security: "Security",
-  ai: "AI",
-  cli: "CLI",
-  go: "Go",
-  devsecops: "DevSecOps",
   cryptography: "Cryptography",
+  architecture: "Architecture",
+  devsecops: "DevSecOps",
+  cli: "CLI",
+  // AI era concepts
+  "harness-engineering": "Harness Engineering",
+  workflow: "Workflow",
+  "claude-code": "Claude Code",
+  cursor: "Cursor",
+  // Format / character
   tutorial: "Tutorial",
   comparison: "Comparison",
-  architecture: "Architecture",
-  "vibe-coding": "Vibe Coding",
+  "deep-dive": "Deep Dive",
+  "founder-story": "Founder Story",
 } as const;
 
 export type TagKey = keyof typeof TAG_VOCABULARY;
@@ -22,3 +68,13 @@ export function isValidTag(tag: string): tag is TagKey {
 export function getTagLabel(tag: string): string {
   return (TAG_VOCABULARY as Record<string, string>)[tag] ?? tag;
 }
+
+// ---------------------------------------------------------------------------
+// Retired vocabulary — kept here so route generation can emit 301 redirects
+// for any external links that still point at the old slugs.
+// ---------------------------------------------------------------------------
+export const RETIRED_TAG_REDIRECTS: Record<string, string> = {
+  ai: "vibe-coding", // redirect target is a *category*, handled by middleware
+  go: "architecture",
+  "vibe-coding": "__category__", // the tag was promoted to a category
+};

--- a/apps/web/src/lib/track.ts
+++ b/apps/web/src/lib/track.ts
@@ -35,7 +35,18 @@ type EventMap = {
 
   // tech-blog Phase 2 (FR-32 ~ FR-37)
   blog_copy_code: { slug: string; language: string };
-  blog_tag_filter: { tag: string; from: "index" | "post_header" | "card" };
+  // blog-categories-and-tooling — tag filter now fires from the multi-select
+  // filter widget too, and sometimes without a specific tag (clear all).
+  blog_tag_filter: {
+    tag?: string;
+    action?: "add" | "remove" | "clear_all";
+    from: "index" | "post_header" | "card" | "filter";
+  };
+  // blog-categories-and-tooling — category pill click on /blog index.
+  blog_category_filter: {
+    category: string;
+    from: "index" | "active";
+  };
   blog_related_click: { fromSlug: string; toSlug: string };
   blog_rss_click: { location: "footer" | "blog_header" };
   blog_external_link: { slug: string; domain: string };

--- a/docs/01-plan/blog-categories-and-tooling.plan.md
+++ b/docs/01-plan/blog-categories-and-tooling.plan.md
@@ -1,0 +1,343 @@
+# Blog Categorization + /blog-new Skill Enhancement — Plan
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `blog-categories-and-tooling` |
+| 기반 논의 | 2026-04-23 대화 세션 (PRD 없음 — 점진 개선) |
+| 브랜치 | `feature/blog-categories` (origin/staging 베이스) |
+| 후속 feature | `blog-content-batch-2026-04-23` (별도 plan 문서) |
+| 총 공수 | ~10-12 인시간 |
+| 기간 | 1-2일 집중 |
+
+---
+
+## 1. 컨텍스트
+
+### 1.1 문제 (As-is)
+
+현재 블로그(`apps/web/content/blog/*.mdx`)는 **단일 평면 tag vocabulary 10개**만 운영:
+
+```
+security · ai · cli · go · devsecops · cryptography ·
+tutorial · comparison · architecture · vibe-coding
+```
+
+- 제품/기술 중심이라 **개념·철학 글을 담을 카테고리 부재**
+- `ai`가 너무 포괄적 — "AI 보조 개발"과 "AI 노동 철학"이 같은 tag로 묶임
+- `go`는 1편만 사용 (과잉 세분화)
+- 탐색 단위가 tag 하나뿐 — 독자가 "이 블로그는 무엇에 관한 블로그인가" 파악 어려움
+
+### 1.2 목표 (To-be)
+
+**2-layer taxonomy** 도입:
+
+- **Category (필수 1개)** — 4개 버킷. 블로그 탐색의 primary 축.
+  - `tools`, `engineering`, `vibe-coding`, `philosophy`
+- **Tag (2-4개 복수 선택)** — 15개 curated vocabulary. 세부 주제 분류 + 교차 탐색.
+
+독자 경험:
+- 카테고리 4개 pill로 즉시 콘텐츠 정체성 이해
+- 인스타그램식 tag 필터로 교차 탐색 (`#security` + `#claude-code`)
+- 기존 URL 전부 보존 (SEO 자산 보호)
+
+### 1.3 확정 결정 (대화 기반)
+
+사용자와 확정된 사항:
+
+| 질문 | 결정 |
+|------|------|
+| Category 4개 구성 | ✅ `tools` / `engineering` / `vibe-coding` / `philosophy` |
+| Tag vocabulary 유지 여부 | ✅ 유지 (SEO 자산 보존 + 다축 표현력) |
+| URL 구조 | ✅ Option A — `/blog/<slug>` 유지 |
+| 언어 | ✅ 영문 전용 (category/tag 화면 표시 + slug) |
+| Tag 필터 UI 범위 | ✅ 표준 (접힘 + 검색창 + URL 쿼리 동기화) |
+
+---
+
+## 2. 스코프 (구현 항목 22개)
+
+### 2.1 Data model — TAG_VOCABULARY 재편 + CATEGORY_VOCABULARY 신설
+
+**파일**: `apps/web/src/lib/tags.ts`
+
+```ts
+// NEW
+export const CATEGORY_VOCABULARY = {
+  tools:       "Tools",        // Products (tene, bkit, ADK family)
+  engineering: "Engineering",  // Concepts, architecture, crypto
+  "vibe-coding": "Vibe Coding", // AI-assisted dev practice
+  philosophy:  "Philosophy",   // AI era essays, opinion, founder story
+} as const;
+
+export type CategoryKey = keyof typeof CATEGORY_VOCABULARY;
+
+// REVISED
+export const TAG_VOCABULARY = {
+  // Products
+  tene:                 "tene",
+  bkit:                 "bkit",
+  // Technical domain
+  security:             "Security",
+  cryptography:         "Cryptography",
+  architecture:         "Architecture",
+  devsecops:            "DevSecOps",
+  cli:                  "CLI",
+  // AI era concepts
+  "harness-engineering":"Harness Engineering",
+  workflow:             "Workflow",
+  "claude-code":        "Claude Code",
+  cursor:               "Cursor",
+  // Format / character
+  tutorial:             "Tutorial",
+  comparison:           "Comparison",
+  "deep-dive":          "Deep Dive",
+  "founder-story":      "Founder Story",
+} as const;
+```
+
+**제외**: `ai` (과포괄, category로 대체), `go` (과세분화), `vibe-coding` (category로 승격)
+
+### 2.2 Frontmatter schema 확장
+
+**파일**: `apps/web/src/lib/blog.ts` (BlogPostMeta 타입 + 파싱)
+
+```ts
+export interface BlogPostMeta {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  updatedAt?: string;
+  category: CategoryKey;          // NEW - 필수
+  tags: TagKey[];                  // 기존, 2-4개
+  author: string;
+  cover?: string;
+  canonicalUrl?: string;
+  faqs: { question: string; answer: string }[];
+}
+```
+
+`gray-matter` 파싱 후 validation에서 `category` 누락/잘못된 값 빌드 실패 처리.
+
+### 2.3 기존 9편 MDX frontmatter 마이그레이션
+
+각 파일 frontmatter에 `category:` 1줄 추가 + tags 재편.
+
+| 글 | 새 Category | 새 Tags |
+|---|---|---|
+| `ai-reads-env.mdx` | `vibe-coding` | security, devsecops, tene |
+| `bkit-harness-engineering-vibe-coding.mdx` | `vibe-coding` | bkit, harness-engineering, workflow |
+| `bkit-pdca-for-claude-code.mdx` | `vibe-coding` | bkit, workflow, tutorial, claude-code |
+| `claude-code-safe-api-keys.mdx` | `vibe-coding` | tene, claude-code, security, tutorial |
+| `cursor-secret-management-2026.mdx` | `vibe-coding` | tene, cursor, security, tutorial |
+| `doppler-alternative-journey.mdx` | `tools` | tene, comparison, founder-story |
+| `dotenv-vault-alternatives.mdx` | `tools` | tene, comparison, tutorial, devsecops |
+| `migrate-env-60s.mdx` | `tools` | tene, tutorial, cli |
+| `xchacha20-for-devs.mdx` | `engineering` | cryptography, architecture, security, tene |
+
+분포: `vibe-coding` 5 · `tools` 3 · `engineering` 1 · `philosophy` 0.
+→ philosophy 0편 상태. 후속 plan(`blog-content-batch-*`)에서 채움.
+
+### 2.4 Routes
+
+**유지 (변경 없음)**:
+- `/blog` — 인덱스
+- `/blog/<slug>` — 개별 글 (canonical 유지 → **SEO 보호**)
+- `/blog/tag/<tag>` — tag 필터 페이지 (15개)
+
+**신규**:
+- `/blog/category/<category>` — category 필터 페이지 (4개)
+- `/blog?tags=a,b` — 인스타식 멀티 tag 필터 (query param 기반 클라이언트 필터)
+
+**파일**:
+- `apps/web/src/app/blog/category/[category]/page.tsx` (신규, generateStaticParams)
+- `apps/web/src/app/blog/page.tsx` (수정 — 필터 UI 추가)
+
+### 2.5 UI 컴포넌트
+
+| 위치 | 컴포넌트 | 동작 |
+|---|---|---|
+| `/blog` 상단 | 카테고리 pill 4개 | 클릭 시 `/blog/category/<slug>` 이동 |
+| `/blog` 중단 | `<TagFilter>` | 기본 접힘. "Filter by topic ▾" 클릭 시 확장: 검색창 + top 5 tag pills + "Show all" → 전체 15개 |
+| `/blog/category/<x>` 상단 | category 제목 + 설명 + 해당 글 목록 | sitemap + SEO |
+| `/blog/tag/<x>` 상단 | tag 제목 + count + 해당 글 목록 | 기존 동작 유지 |
+| 글 카드 | category 배지 (색상 구분) + tag 2개만 표시 + `+N more` | 모바일에서도 깔끔 |
+| 글 상세 | Hero 아래에 category + 전체 tag 표시 | 기존 유사 |
+
+**신규 파일**:
+- `apps/web/src/components/blog/category-pills.tsx`
+- `apps/web/src/components/blog/tag-filter.tsx` (검색 + 선택 + URL 동기화)
+- `apps/web/src/components/blog/category-badge.tsx`
+
+### 2.6 Sitemap / RSS / robots
+
+**파일**: `apps/web/src/app/sitemap.ts`
+
+추가 URL:
+- `/blog/category/tools`
+- `/blog/category/engineering`
+- `/blog/category/vibe-coding`
+- `/blog/category/philosophy`
+
+`/blog?tags=...`는 URL query라 sitemap 비대상.
+
+**RSS**: 변경 없음 (글별 canonical 그대로).
+
+### 2.7 Landing page blog 섹션 개선
+
+**파일**: `apps/web/src/app/page.tsx` (또는 Hero 주변 섹션)
+
+- Blog preview 섹션에 **카테고리별 최신 1편씩 표시** (4×1 grid)
+- 현재는 최신 3편만 표시 — category별 균등 노출로 변경
+
+### 2.8 /blog-new 스킬 및 문서 업데이트
+
+**스킬 관련 파일** (tene-biz 쪽):
+- `.claude/commands/blog-new.md`:
+  - Phase 1 AskUserQuestion에 Category 질문 추가 (3개 → 4개 질문)
+  - Plan 출력 포맷에 Category 필드 추가
+- `.claude/rules/blog-content.md`:
+  - §1 Frontmatter 스키마 `category` 필수 필드 추가
+  - §2 Tag vocabulary 업데이트 (10개 → 15개)
+  - §2에 Category 정의 섹션 추가
+- `.claude/rules/blog-pdca-workflow.md`:
+  - Phase 1 체크리스트에 "category 결정" 1줄 추가
+- `.claude/templates/blog/article.template.mdx`:
+  - frontmatter 예시에 `category:` 추가
+- `.claude/templates/blog/pre-publish-checklist.md`:
+  - category 유효성 확인 항목 추가
+
+### 2.9 Layout contract 검증 재확인
+
+**파일**: `.claude/rules/blog-content.md §7.1`
+
+변경 없음 예상. 카테고리 배지 + tag filter 추가되지만:
+- hero / breadcrumb / related 폭 = `max-w-3xl` 유지
+- article grid = `720px 220px` 유지
+- shiki code block 스타일 유지
+
+Chrome MCP QA 시 추가 체크: 카테고리 pill이 모바일(375/390px)에서 overflow 없이 wrap되는지.
+
+---
+
+## 3. Role 분배 (Agent Teams 기준)
+
+| Role | 담당 | 공수 |
+|------|------|------|
+| **Frontend Architect** | 2.4 Routes · 2.5 UI 5종 · 2.6 Sitemap · 2.7 Landing | 6h |
+| **Product Manager** | 2.3 9편 frontmatter 마이그 + 분류 리뷰 | 1h |
+| **Skill Author** (사용자 + Claude main) | 2.8 `.claude/` 4종 업데이트 | 2h |
+| **QA** (Chrome MCP subagent) | 2.9 Layout contract + 9편 회귀 검증 | 1h |
+| **Backend** | 2.1-2.2 tags.ts + blog.ts schema | 1h |
+
+---
+
+## 4. 타임라인
+
+### Day 1 — Schema + Migration (4h)
+
+- [ ] 2.1 `tags.ts` CATEGORY_VOCABULARY 추가 + TAG_VOCABULARY 재편 (30m)
+- [ ] 2.2 `blog.ts` parser + 타입 확장 (30m)
+- [ ] 2.3 기존 9편 frontmatter 마이그레이션 (1h, 각 ~7분)
+- [ ] 2.8 `.claude/rules/blog-content.md` vocabulary 섹션 업데이트 (1h)
+- [ ] Build + 기존 9편 검증 (빌드 통과, 카테고리 페이지 생성 확인) (1h)
+
+### Day 2 — UI + Routes + Skill (5-6h)
+
+- [ ] 2.4 `/blog/category/[category]/page.tsx` 신규 (1h)
+- [ ] 2.5 `<CategoryPills>` · `<TagFilter>` · `<CategoryBadge>` 3개 (2.5h)
+- [ ] 2.6 sitemap.ts 업데이트 (15m)
+- [ ] 2.7 landing blog 섹션 — 카테고리별 1편씩 (45m)
+- [ ] 2.8 blog-new 스킬 Phase 1 수정 (30m)
+
+### Day 2 끝 — QA + Commit (1h)
+
+- [ ] 2.9 Chrome MCP 회귀 테스트 (9편 + 4 카테고리 페이지 + 인덱스 필터) (30m)
+- [ ] README / CHANGELOG 업데이트 (15m)
+- [ ] Commit 분할 (2-3 커밋) + PR to staging (15m)
+
+---
+
+## 5. 검증 (Success Criteria)
+
+### 5.1 자동 빌드 검증 (CI 통과 + HTML grep)
+
+- `npx next build` → 에러 0 (9편 + 새 라우트 4개 SSG 포함)
+- `grep -c "category" .next/server/app/blog/<slug>.html` → 각 글 ≥ 1
+- `curl /sitemap.xml | grep -c "/blog/category/"` → 4
+- `curl /blog/category/tools` → 200
+- `curl /blog/category/philosophy` → 200 (글 0편이어도 "no posts yet" 플레이스홀더)
+
+### 5.2 Chrome MCP layout 회귀 (blog-content.md §7.1)
+
+기존 9편 전부 재검증:
+- `articleWidth` = 720 (lg+)
+- `gridCols` = `"720px 220px"`
+- `horizontalScroll` = false (375/390/768px viewport)
+- 신규: `<CategoryPills>` overflow 없음
+- 신규: `<TagFilter>` 클릭 후 URL 쿼리 업데이트, 뒤로가기 시 상태 복원
+
+### 5.3 SEO 영향 확인
+
+- 기존 9편 canonical URL **변경 없음** (frontmatter의 `canonicalUrl`은 현행 유지)
+- 기존 `/blog/tag/<tag>` 10개 URL 유지 (`go`, `ai` 2개는 제거 — 리디렉션 또는 404)
+- 신규 `/blog/category/*` 4개 URL 생성 + sitemap 등록
+- `article:section` meta는 category로 업데이트 (Schema.org `BlogPosting.articleSection`)
+
+### 5.4 /blog-new 스킬 회귀
+
+다음 이터레이션 때 `/blog-new` 실행 시:
+- AskUserQuestion에 Category 선택지 4개 노출
+- Plan 출력에 Category 필드 포함
+- 생성된 MDX에 `category:` 포함
+- Phase 4 Check에서 category 값이 vocabulary에 속하는지 검증
+
+---
+
+## 6. 리스크 & 완화
+
+| 리스크 | 확률 | 영향 | 완화 |
+|------|:---:|:---:|------|
+| 기존 `go`·`ai` tag 페이지 유입 트래픽 유실 | 중 | 소 | 301 redirect: `/blog/tag/ai` → `/blog/category/vibe-coding`, `/blog/tag/go` → `/blog/tag/cli` |
+| 카테고리 배지가 카드 레이아웃 깨뜨림 | 낮 | 중 | Chrome MCP QA 모바일 375px 필수 |
+| `<TagFilter>` URL 쿼리 동기화 bug (뒤로가기 깨짐) | 중 | 중 | `useSearchParams` + `router.replace` 패턴. 기본 테스트 케이스 3개 |
+| /blog-new 템플릿 불일치로 새 글 빌드 실패 | 낮 | 중 | Phase 4 build 체크 템플릿 기반 |
+| `category` 필드 누락된 기존 글 빌드 실패 | 중 | 고 | 마이그레이션 누락 없이 9편 전부 수정, CI grep 검증 |
+
+---
+
+## 7. Rollback
+
+문제 발생 시:
+
+1. **빌드 실패**: feature 브랜치 버리고 staging으로 복귀. 기존 9편 frontmatter 수정 없음 → 영향 0.
+2. **배포 후 SEO 하락 감지 (7일 모니터)**: category 페이지만 noindex 처리 후 원인 조사. frontmatter 롤백 가능.
+3. **/blog-new 스킬 회귀**: `.claude/` 디렉터리만 이전 버전으로 복구. 본 repo 코드는 영향 없음 (symlink 구조).
+
+---
+
+## 8. 의존성 및 후속 작업
+
+- **선행**: 없음
+- **병행**: homebrew 결정 (`feature/homebrew-tap` 브랜치 paused) — 별개
+- **후속**:
+  - `blog-content-batch-2026-04-23.plan.md` — 오늘 작성할 글 batch (별도 plan 문서에서 관리)
+  - 추후: `/blog/category/philosophy`가 비어 있으므로 우선순위 높음
+  - 추후: `ai-discoverability` plan에서 언급된 Blog 관련 항목 (article:section meta 등) 통합
+
+---
+
+## 9. 참조
+
+- 대화 세션: 2026-04-23 (blog categorization discussion)
+- 기존 tag 정의: `apps/web/src/lib/tags.ts` (10개)
+- 기존 blog parser: `apps/web/src/lib/blog.ts`
+- Layout contract: `tene-biz/.claude/rules/blog-content.md §7.1`
+- Blog PDCA workflow: `tene-biz/.claude/rules/blog-pdca-workflow.md`
+- Article 템플릿: `tene-biz/.claude/templates/blog/article.template.mdx`
+- Existing blog posts: `apps/web/content/blog/*.mdx` (9편)
+
+---
+
+**작성**: 2026-04-23 (Claude main, discussion-based, no separate PRD)
+**검토 대기**: 사용자 승인 후 `/pdca design` 단계 진입

--- a/docs/01-plan/blog-content-batch-2026-04-23.plan.md
+++ b/docs/01-plan/blog-content-batch-2026-04-23.plan.md
@@ -1,0 +1,330 @@
+# Blog Content Batch 2026-04-23 — Plan
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `blog-content-batch-2026-04-23` |
+| 의존성 (선행) | `blog-categories-and-tooling.plan.md` (category 도입 먼저 완료) |
+| 브랜치 | `feature/blog-batch-w17` (별도, `feature/blog-categories` merge 이후 생성) |
+| 총 공수 | ~6-10 인시간 (선택 조합에 따라) |
+
+---
+
+## 1. 컨텍스트
+
+`blog-categories-and-tooling` plan이 도입될 시점 각 카테고리 콘텐츠 분포:
+
+| Category | 편수 (migration 후) | 상태 |
+|---|:-:|---|
+| `tools` | 3 | 적정 |
+| `engineering` | 1 | **빈약** — 우선 보강 |
+| `vibe-coding` | 5 | 풍부 |
+| `philosophy` | **0** | **공백** — 최우선 |
+
+### 1.1 목표
+
+오늘 중 2-4편 추가 발행으로:
+- `philosophy` 0 → 최소 1편 (카테고리 정체성 확립)
+- `engineering` 1 → 2편 이상 (technical depth 층 보강)
+- `tools`와 `vibe-coding`은 상호 링크 강화 목적이면 추가 가능
+
+### 1.2 제약
+
+- 모든 글이 **새 2-layer taxonomy**에 맞게 category + tags 설정
+- 기존 layout contract (`.claude/rules/blog-content.md §7.1`) 준수
+- 각 글 QA: Chrome MCP 레이아웃 검증 + build/sitemap/RSS 확인
+- 상호 링크 최소 2개 (내부)
+
+---
+
+## 2. 후보 글 6개
+
+### C1. Philosophy — "Why I built tene: the case for local-first in the AI era"
+
+| 항목 | 값 |
+|---|---|
+| Category | `philosophy` |
+| Tags | `tene`, `founder-story`, `security` |
+| 예상 길이 | ~1,400 words |
+| 난이도 | 중 (설득력 있게 써야) |
+| Hook | "I paid Doppler for 18 months. Then I wrote `tene init` one weekend." |
+| 핵심 주장 | Cloud secret manager가 아니라 local-first를 택한 이유 3가지 (AI 위협 모델 + Single founder 관리 가능성 + 데이터 주권) |
+| 가치 | **Founder voice 첫 글**. 구글 검색 롱테일 + HN 공유 친화적 |
+
+### C2. Engineering — "Argon2id + OS Keychain: how tene stores the master key"
+
+| 항목 | 값 |
+|---|---|
+| Category | `engineering` |
+| Tags | `cryptography`, `architecture`, `security`, `tene` |
+| 예상 길이 | ~1,400 words |
+| 난이도 | 고 (기술 정확도 필요) |
+| Hook | "Your password is not the key. Your password *derives* the key." |
+| 핵심 주장 | KDF (Argon2id) + OS keychain integration (macOS Keychain / libsecret / Credential Vault) 아키텍처 |
+| 가치 | XChaCha20 글의 **짝 글**. 암호학 독자 retention. `engineering` 카테고리 강화 |
+
+### C3. Vibe Coding — "Running tene in GitHub Actions"
+
+| 항목 | 값 |
+|---|---|
+| Category | `vibe-coding` |
+| Tags | `tene`, `devsecops`, `tutorial`, `cli` |
+| 예상 길이 | ~1,100 words |
+| 난이도 | 중 (실제 workflow YAML 필요) |
+| Hook | "Your CI has secrets. So does your IDE. They should never meet." |
+| 핵심 주장 | GitHub Actions + `TENE_MASTER_PASSWORD` secret + `--no-keychain` 플래그 + `tene run --` 패턴 |
+| 가치 | CI/CD 실무 니즈. **"tene in production" SEO 대응**. 현재 CI 관련 글 0편 |
+
+### C4. Tools — "tene + bkit: the full AI-agent dev loop"
+
+| 항목 | 값 |
+|---|---|
+| Category | `tools` |
+| Tags | `tene`, `bkit`, `workflow`, `tutorial` |
+| 예상 길이 | ~1,600 words |
+| 난이도 | 중 |
+| Hook | "bkit plans the feature. tene injects the keys. Claude writes the code — and never sees either." |
+| 핵심 주장 | `/pdca plan` → `/pdca do` + `tene run -- <test>` 통합 워크플로우 |
+| 가치 | 오늘 올린 bkit 2편의 **3부작 완성편**. 내부 링크 밀도 +30% |
+
+### C5. Philosophy — "The AI-agent secret leak problem in 2026: state of the industry"
+
+| 항목 | 값 |
+|---|---|
+| Category | `philosophy` |
+| Tags | `security`, `devsecops`, `tene` |
+| 예상 길이 | ~2,000 words |
+| 난이도 | 고 (리서치 + 사실 확인) |
+| Hook | "In 2024, AI agents accidentally logged secrets. In 2026, agents accidentally publish them to GitHub." |
+| 핵심 주장 | 업계 전반 상태 리뷰: Copilot 유출 사건, Claude Code 업데이트 트렌드, 시장 반응 |
+| 가치 | **Pillar / manifesto 성격**. HN Show HN 후보. Dev.to 크로스포스트 최적. 단 **리서치 부담 큼** |
+
+### C6. Vibe Coding — "Windsurf + tene"
+
+| 항목 | 값 |
+|---|---|
+| Category | `vibe-coding` |
+| Tags | `tene`, `security`, `tutorial` |
+| 예상 길이 | ~900 words |
+| 난이도 | 낮 (기존 Claude Code / Cursor 글 템플릿 복제) |
+| Hook | "Windsurf is Cursor's quiet cousin. Here's the same safe pattern for it." |
+| 핵심 주장 | `.windsurfrules` 파일 기반 rule + `tene run -- windsurf` |
+| 가치 | 편집기 매트릭스 3번째. Landing의 "Supported AI Editors" 표 보강 |
+
+---
+
+## 3. 각 글 의 예상 outline (간략)
+
+### C1 — Why I built tene (philosophy, ~1,400w)
+
+```
+H1: Why I built tene (frontmatter title)
+
+H2 1. Eighteen months on Doppler  (hook + 개인 경험)
+H2 2. The AI agent changed the threat model
+H2 3. Why "local-first" isn't nostalgia — it's operational
+H2 4. What I gave up (honest trade-offs)
+H2 5. What I'll build next (local-first 확장 로드맵)
+H2 6. Closing — if your secrets are for humans, stay cloud. If they're for agents, come local.
+
+Code blocks: 2 (cost table + tene init output)
+MDX components: Callout × 1 (투자자/팀 고려사항)
+Internal links: /blog/doppler-alternative-journey, /blog/ai-reads-env
+```
+
+### C2 — Argon2id + OS Keychain (engineering, ~1,400w)
+
+```
+H2 1. The password is not the key
+H2 2. Argon2id in one paragraph (Why not PBKDF2/bcrypt/scrypt)
+H2 3. Parameters that actually matter (memory 64MB / time 3 / lanes 1)
+H2 4. Key cache: where macOS / Linux / Windows store the derived key
+H2 5. The handshake: password -> KDF -> cache -> decrypt vault
+H2 6. Rotating / revoking (passwd, recover, full rewrap)
+H2 7. Summary — 3 invariants tene protects
+
+Code blocks: 4 (Argon2id params, keychain API calls per OS, rotate command, test)
+Internal links: /blog/xchacha20-for-devs, /blog/ai-reads-env
+```
+
+### C3 — tene in GitHub Actions (vibe-coding, ~1,100w)
+
+```
+H2 1. Two secret stores, one leak
+H2 2. What GitHub Actions' default setup misses
+H2 3. tene + Actions: the 4-step setup
+H2 4. Example: Stripe webhook test in CI
+H2 5. Rotation without restarting CI
+H2 6. Gotchas (keychain absence, masked stdout)
+
+Code blocks: 3 (workflow YAML, tene run in CI, rotation)
+Internal links: /blog/claude-code-safe-api-keys, /blog/migrate-env-60s
+```
+
+### C4 — tene + bkit full loop (tools, ~1,600w)
+
+```
+H2 1. The gap between "plan" and "run"
+H2 2. bkit plans the feature (/pdca pm -> design)
+H2 3. tene holds the keys (.tene/ + CLAUDE.md rule)
+H2 4. /pdca do with runtime injection (tene run -- npm test)
+H2 5. /pdca analyze + gap-detector (no secrets in design docs)
+H2 6. Completing the loop: ship safely
+H2 7. Takeaway — method + primitives = reliable AI-agent dev
+
+Code blocks: 4 (PDCA flow, tene-injected test, CLAUDE.md excerpt, gap-detector output)
+Internal links: /blog/bkit-harness-engineering-vibe-coding, /blog/bkit-pdca-for-claude-code, /blog/claude-code-safe-api-keys
+```
+
+### C5 — AI-agent secret leak state (philosophy, ~2,000w)
+
+```
+H2 1. 2024: the year agents learned to log
+H2 2. 2025-early: the GitHub Copilot incidents (cite specific cases)
+H2 3. 2025-late: the Claude Code transition
+H2 4. 2026 now: three patterns the industry converged on
+H2 5. What's still broken (agent output logs, cloud console copy-paste)
+H2 6. What tene addresses, what it does not (honest scope)
+H2 7. Forecast — where this goes in 2027
+
+Code blocks: 2 (leak reproduction example, scope matrix)
+Internal links: /blog/ai-reads-env, /blog/doppler-alternative-journey
+External refs: 6-8 news/blog posts (주의: 사실 확인 필요)
+```
+
+### C6 — Windsurf + tene (vibe-coding, ~900w)
+
+```
+H2 1. Windsurf: Cursor's quieter cousin
+H2 2. The .windsurfrules file
+H2 3. tene init --windsurf (if command exists, else manual)
+H2 4. Running with injected secrets
+H2 5. Common mistakes
+H2 6. Summary
+
+Code blocks: 3 (install, rule file, run)
+Internal links: /blog/cursor-secret-management-2026, /blog/claude-code-safe-api-keys
+```
+
+---
+
+## 4. 권장 조합 3종
+
+### 조합 A (최소 — 2편, ~4-5h) ⭐ 권장
+
+- **C1** (philosophy gap 해소 · founder voice 첫 글)
+- **C4** (bkit 3부작 완성 · 내부 링크 밀도 강화)
+
+**근거**: 오늘 추가 효과가 가장 큰 2편. 각 카테고리 성격 확립 + 기존 콘텐츠 가치 증폭.
+
+### 조합 B (균형 — 3편, ~7-8h)
+
+- **C1** (philosophy 1편)
+- **C2** (engineering 1편)
+- **C4** (tools + internal links)
+
+**근거**: 3개 카테고리 모두 +1 만들어서 새 taxonomy 도입 시점에 분포 정돈. `philosophy` 1 · `engineering` 2 · `tools` 4 · `vibe-coding` 5. 고르게 분포.
+
+### 조합 C (풀 세트 — 4편, ~10h)
+
+- **C1** + **C2** + **C3** + **C4**
+
+**근거**: 하루에 네 카테고리 모두 +1. 피로하지만 taxonomy 첫 공개에 최대 임팩트.
+
+### 조합 D (manifesto 도전 — 1편, ~5h)
+
+- **C5** 단독
+
+**근거**: state-of-industry 에세이는 단독 임팩트 글. 다만 리서치 부담 크고 팩트 확인 필요해 실패 리스크 존재.
+
+---
+
+## 5. 공통 품질 기준 (모든 글 공통)
+
+작성 전 확정 (Phase 1 Plan):
+- [ ] Category 1개 선택 (4개 중)
+- [ ] Tags 2-4개 (15개 vocabulary에서)
+- [ ] Slug 승인 (≤ 60자, kebab-case)
+- [ ] Length 목표 (800/1,200/2,000 중)
+- [ ] Opening hook 1줄
+
+작성 (Phase 3 Do):
+- [ ] Frontmatter 완전 (`category` 필수)
+- [ ] H2 4-8개, 각 ASCII 문자
+- [ ] Code block 실제 tene/bkit 명령만
+- [ ] Internal 링크 ≥ 2
+- [ ] FAQ ≥ 3 (BlogPosting + FAQPage JSON-LD)
+- [ ] OG image (slug별 `/public/blog/<slug>/` 또는 재사용 `/public/demo/*`)
+
+검증 (Phase 4 Check + Phase 6 QA):
+- [ ] `next build` 성공 · SSG 라우트 생성
+- [ ] `grep "@type\":\"BlogPosting\"" .next/server/app/blog/<slug>.html` → 1
+- [ ] `grep "@type\":\"FAQPage\"" .next/...` → 1
+- [ ] Chrome MCP layout 16 체크 통과
+- [ ] 카테고리 pill에 포함됨 (신설)
+- [ ] tag 필터에서 클릭 시 해당 글 표시
+
+---
+
+## 6. 타임라인
+
+### Day 0 (오늘, 선택 조합에 따라)
+
+**조합 A 선택 시**:
+- T+0h: C1 Plan (Phase 1-2, 15m)
+- T+0.25h: C1 작성 (Phase 3, 90m)
+- T+1.75h: C1 검증 + commit (30m)
+- T+2.25h: C4 Plan (15m)
+- T+2.5h: C4 작성 (120m)
+- T+4.5h: C4 검증 + commit (30m)
+- T+5h: PR staging
+
+**조합 B 선택 시**: 위 + C2 (60m Plan + 2.5h Do + 30m QA = 4h 추가)
+
+**조합 C 선택 시**: 위 + C3 (45m Plan + 2h Do + 30m QA = 3.5h 추가)
+
+---
+
+## 7. 의존 순서
+
+```
+[blog-categories-and-tooling.plan.md 완료]
+  ├─ 카테고리 도입 PR merge to staging
+  ├─ migrations 완료 (9편 frontmatter)
+  └─ /blog-new 스킬 업데이트 (category 질문 추가)
+        │
+        ▼
+[blog-content-batch-2026-04-23.plan.md 시작]
+  ├─ 조합 결정 (A/B/C/D)
+  ├─ 각 글 /blog-new 호출 (새 스킬로, category 선택됨)
+  ├─ 글별 commit
+  └─ 단일 PR staging → main
+```
+
+**중요**: 카테고리 도입이 먼저 완료돼야 새 글이 정상 분류됨. 두 plan을 동일 PR에 묶지 않음 (스코프 분리 + 리스크 격리).
+
+---
+
+## 8. 측정 (발행 후 7일)
+
+| 지표 | 목표 |
+|------|------|
+| 신규 글 impressions (Google Search Console) | ≥ 100 per article |
+| `/blog/category/*` 4개 URL 인덱싱 | 전부 "Indexed" 상태 |
+| 기존 9편 ranking 변동 | ±3위 이내 (유지) |
+| HN / Reddit 공유 수 (manual 추적) | 조합 A ≥ 10, 조합 C ≥ 30 |
+| 블로그 → tene.sh 홈 CTR | ≥ 3% |
+
+---
+
+## 9. 참조
+
+- 선행 plan: `docs/01-plan/blog-categories-and-tooling.plan.md`
+- Content rules: `tene-biz/.claude/rules/blog-content.md`
+- PDCA workflow: `tene-biz/.claude/rules/blog-pdca-workflow.md`
+- 기존 글: `apps/web/content/blog/*.mdx` (9편)
+- Growth routine: `tene-biz/.claude/rules/growth-routine.md` (발행 후 cross-share)
+
+---
+
+**작성**: 2026-04-23 (Claude main, discussion-based)
+**대기**: 조합 A/B/C/D 중 결정 + 선행 plan 승인

--- a/docs/02-design/features/blog-categories-and-tooling.design.md
+++ b/docs/02-design/features/blog-categories-and-tooling.design.md
@@ -1,0 +1,328 @@
+# Blog Categories + Tooling — Design
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `blog-categories-and-tooling` |
+| 기반 Plan | `docs/01-plan/blog-categories-and-tooling.plan.md` |
+| 브랜치 | `feature/blog-categories` |
+
+---
+
+## 1. 아키텍처 결정
+
+### 1.1 Data layer — 2개 export 병행
+
+`src/lib/tags.ts`에 `CATEGORY_VOCABULARY`와 `TAG_VOCABULARY`를 동시 export. Category는 1개 필수 + Tag는 2-4개 복수. 서로 독립 평면.
+
+### 1.2 URL 구조 — Option A (기존 URL 전부 보존)
+
+- 글별 canonical URL 전부 그대로 (`https://tene.sh/blog/<slug>`)
+- `/blog/tag/<tag>` 페이지 유지 (15개 vocabulary + dropped `go`/`ai` 301)
+- `/blog/category/<category>` 신규 (4개)
+- `/blog?tags=a,b` query-based 클라이언트 필터 (sitemap 비대상)
+
+### 1.3 Frontmatter — `category` 필수화 전략
+
+- 단일 PR에서 vocabulary 확장 + 9편 마이그레이션 + parser validation 동시 진행
+- blog.ts parser는 category 누락 시 build-time 에러 throw → 역호환성 보호 불필요 (전편 마이그 완료 가정)
+
+### 1.4 기존 tag 중 `go`·`ai`·`vibe-coding` 처리
+
+- `go`: xchacha20 글 1편만 보유. tag 제거 후 `architecture`로 치환
+- `ai`: 5편에 부착. 전부 vibe-coding category로 이동 예정이므로 tag 제거 (중복 방지)
+- `vibe-coding`: tag vocabulary에서 **제거**, category로 승격. 5편의 글에서 tag 제거
+
+---
+
+## 2. 코드 변경 상세 (파일별)
+
+### 2.1 `src/lib/tags.ts`
+
+```ts
+// NEW — 최상단
+export const CATEGORY_VOCABULARY = {
+  tools:        "Tools",
+  engineering:  "Engineering",
+  "vibe-coding": "Vibe Coding",
+  philosophy:   "Philosophy",
+} as const;
+
+export type CategoryKey = keyof typeof CATEGORY_VOCABULARY;
+
+export function isValidCategory(cat: string): cat is CategoryKey {
+  return cat in CATEGORY_VOCABULARY;
+}
+
+export function getCategoryLabel(cat: string): string {
+  return (CATEGORY_VOCABULARY as Record<string, string>)[cat] ?? cat;
+}
+
+// REVISED
+export const TAG_VOCABULARY = {
+  tene:                 "tene",
+  bkit:                 "bkit",
+  security:             "Security",
+  cryptography:         "Cryptography",
+  architecture:         "Architecture",
+  devsecops:            "DevSecOps",
+  cli:                  "CLI",
+  "harness-engineering":"Harness Engineering",
+  workflow:             "Workflow",
+  "claude-code":        "Claude Code",
+  cursor:               "Cursor",
+  tutorial:             "Tutorial",
+  comparison:           "Comparison",
+  "deep-dive":          "Deep Dive",
+  "founder-story":      "Founder Story",
+} as const;
+```
+
+### 2.2 `src/lib/blog.ts`
+
+```ts
+// BlogPostFrontmatter type에 category 추가 (필수)
+export type BlogPostFrontmatter = {
+  // ... 기존
+  category: CategoryKey;  // NEW — 필수
+  tags: TagKey[];         // 타입 좁힘
+  // ...
+};
+
+// loadPost() 내 validation
+const category = data.category as string;
+if (!category) {
+  throw new Error(`[blog] ${slug}: 'category' frontmatter field is required`);
+}
+if (!isValidCategory(category)) {
+  throw new Error(
+    `[blog] ${slug}: invalid category '${category}'. ` +
+    `Allowed: ${Object.keys(CATEGORY_VOCABULARY).join(", ")}`,
+  );
+}
+
+// 신규 helper
+export function getAllCategories(): Array<{ category: string; count: number; label: string }> {
+  const counts = new Map<string, number>();
+  for (const post of getAllPosts()) {
+    counts.set(post.category, (counts.get(post.category) ?? 0) + 1);
+  }
+  // Return all 4 even if count=0 (empty philosophy still visible)
+  return Object.keys(CATEGORY_VOCABULARY).map((cat) => ({
+    category: cat,
+    count: counts.get(cat) ?? 0,
+    label: getCategoryLabel(cat),
+  }));
+}
+
+export function getPostsByCategory(cat: string): BlogPostMeta[] {
+  return getAllPosts().filter((p) => p.category === cat);
+}
+```
+
+### 2.3 Migration — 9편 MDX frontmatter
+
+매핑 테이블 (Plan §2.3에서 확정):
+
+| Slug | category | tags |
+|---|---|---|
+| `ai-reads-env` | `vibe-coding` | `security, devsecops, tene` |
+| `bkit-harness-engineering-vibe-coding` | `vibe-coding` | `bkit, harness-engineering, workflow` |
+| `bkit-pdca-for-claude-code` | `vibe-coding` | `bkit, workflow, tutorial, claude-code` |
+| `claude-code-safe-api-keys` | `vibe-coding` | `tene, claude-code, security, tutorial` |
+| `cursor-secret-management-2026` | `vibe-coding` | `tene, cursor, security, tutorial` |
+| `doppler-alternative-journey` | `tools` | `tene, comparison, founder-story` |
+| `dotenv-vault-alternatives` | `tools` | `tene, comparison, tutorial, devsecops` |
+| `migrate-env-60s` | `tools` | `tene, tutorial, cli` |
+| `xchacha20-for-devs` | `engineering` | `cryptography, architecture, security, tene` |
+
+### 2.4 Routes
+
+#### 2.4.1 `/blog/category/[category]/page.tsx` (신규)
+
+`/blog/tag/[tag]/page.tsx` 패턴 그대로 복제:
+- `generateStaticParams()` → 4개 카테고리
+- `generateMetadata()` → canonical, OG, title
+- 본문: Hero + 해당 카테고리 글 그리드 (`PostCard` 재사용)
+- JSON-LD: `CollectionPage` + `BreadcrumbList`
+
+#### 2.4.2 `/blog/page.tsx` (수정)
+
+- Hero 아래에 `<CategoryPills>` 추가 (4 pill)
+- 기존 `<TagCloud>` 제거 → `<TagFilter>` 로 교체
+- 메인 글 목록은 URL `?tags=` 파라미터 기반 클라이언트 필터 적용
+
+#### 2.4.3 `/blog/tag/[tag]/page.tsx` (수정 — 최소)
+
+- `generateStaticParams()`가 vocabulary 기반 15개 + 기존 dropping 2개 제외
+- 본문 변경 없음
+
+### 2.5 Components
+
+#### 2.5.1 `src/components/blog/category-pills.tsx` (신규)
+
+```tsx
+type Props = { activeCategory?: CategoryKey };
+
+export function CategoryPills({ activeCategory }: Props) {
+  const categories = getAllCategories();  // SSR, build-time
+  return (
+    <div className="flex flex-wrap gap-2 justify-center">
+      {categories.map(({ category, count, label }) => (
+        <Link
+          key={category}
+          href={`/blog/category/${category}`}
+          aria-current={activeCategory === category ? "page" : undefined}
+          className={cn(
+            "rounded-full border px-4 py-2 text-sm transition-colors",
+            activeCategory === category
+              ? "border-accent bg-accent/10 text-foreground"
+              : "border-border bg-surface/60 text-muted hover:border-accent/40 hover:text-foreground",
+          )}
+        >
+          {label} <span className="text-xs opacity-60">({count})</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+#### 2.5.2 `src/components/blog/category-badge.tsx` (신규)
+
+```tsx
+type Props = { category: CategoryKey; size?: "sm" | "md" };
+
+export function CategoryBadge({ category, size = "sm" }: Props) {
+  const label = getCategoryLabel(category);
+  const colors: Record<CategoryKey, string> = {
+    tools:          "bg-blue-500/10 text-blue-400 border-blue-500/20",
+    engineering:    "bg-purple-500/10 text-purple-400 border-purple-500/20",
+    "vibe-coding":  "bg-green-500/10 text-green-400 border-green-500/20",
+    philosophy:     "bg-amber-500/10 text-amber-400 border-amber-500/20",
+  };
+  return (
+    <span className={cn(
+      "inline-flex items-center rounded border",
+      size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm",
+      colors[category],
+    )}>
+      {label}
+    </span>
+  );
+}
+```
+
+#### 2.5.3 `src/components/blog/tag-filter.tsx` (신규)
+
+클라이언트 컴포넌트. URL 쿼리 `?tags=x,y` 동기화.
+
+- 기본: `<details>` 태그로 접힘
+- 펼치면: 검색 input + top 5 tag pills + "Show all 15" 토글
+- 선택/해제 시 URL 업데이트 (`useSearchParams` + `useRouter.replace`)
+- AND 모드 (선택된 모든 tag 포함하는 글만 표시)
+- Props: `allTags: {tag, count}[]`, `onChange(selected: string[])`
+
+Parent (`/blog/page.tsx`)에서 필터된 글 목록 렌더.
+
+#### 2.5.4 `src/components/blog/post-card.tsx` (수정)
+
+- 카드 상단에 `<CategoryBadge category={post.category} />` 추가
+- tag 표시 3개 → 2개로 줄임 (+ `+N more` 생략 기호)
+
+### 2.6 `src/app/sitemap.ts` (수정)
+
+```ts
+// 추가
+const blogCategoryUrls: MetadataRoute.Sitemap =
+  getAllCategories().map(({ category }) => ({
+    url: `${base}/blog/category/${category}`,
+    lastModified,
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
+
+// return에 ...blogCategoryUrls 포함
+// blogTagUrls는 기존 유지 (vocabulary 기반 15개만)
+```
+
+### 2.7 Landing (`src/app/page.tsx`) — 블로그 섹션 개선
+
+기존: 최신 블로그 3편 (또는 N편) 그리드
+변경: 카테고리별 최신 1편씩 4개 그리드 (없는 카테고리는 "Coming soon" 플레이스홀더)
+
+실제 블로그 섹션이 landing에 있는지 확인 후 적용. 없으면 생략 가능.
+
+### 2.8 /blog-new 스킬 업데이트 (`tene-biz/.claude/`)
+
+#### 2.8.1 `.claude/rules/blog-content.md`
+
+- §1 Frontmatter schema에 `category: {slug}` 필수 필드 추가
+- §2 tag vocabulary 섹션 전면 교체 (10 → 15)
+- §2에 Category 섹션 신설 (4개 설명)
+
+#### 2.8.2 `.claude/rules/blog-pdca-workflow.md`
+
+- Phase 1 체크리스트에 "Category 결정" 1줄 추가
+- AskUserQuestion 템플릿에 Q0 추가 (Category 선택)
+
+#### 2.8.3 `.claude/templates/blog/article.template.mdx`
+
+- frontmatter 예시에 `category:` 1줄 추가
+
+#### 2.8.4 `.claude/templates/blog/pre-publish-checklist.md` (존재 시)
+
+- category 유효성 확인 항목 추가
+
+---
+
+## 3. 비기능 요구 (NFR)
+
+- **SEO**: 9편 canonical URL 불변. sitemap 추가 4개. Google Search Console 재제출.
+- **성능**: 모든 페이지 정적 (SSG). 필터는 클라이언트 전용 JS — 번들 < 5 KB gzipped.
+- **접근성**: CategoryPills에 `aria-current`, TagFilter에 `aria-expanded`.
+- **Layout contract**: `.claude/rules/blog-content.md §7.1` 준수. 카테고리 Pill이 모바일 viewport(375/390px)에서 overflow 없이 wrap.
+
+## 4. 검증
+
+### 4.1 빌드 검증
+- `npx next build` 에러 0
+- `/blog/category/<cat>` 4개 정적 경로 생성
+- 기존 9편 canonical URL 불변
+
+### 4.2 Chrome MCP QA (Phase 6)
+- 9편 상세 레이아웃 (hero/article/toc/related 폭)
+- `/blog` 인덱스 카테고리 pill + tag filter 인터랙션
+- `/blog/category/<cat>` 4개 페이지 메타/레이아웃
+- Console errors = 0
+
+### 4.3 SEO 회귀
+- `grep -c "@type\":\"BlogPosting\"" .next/server/app/blog/<slug>.html` → 1 (9편)
+- `curl /sitemap.xml | grep -c "/blog/category/"` → 4
+- `curl /blog/tag/ai` → 301 or 404 (no longer vocabulary)
+
+---
+
+## 5. 구현 순서 (tasks)
+
+1. `src/lib/tags.ts` — vocabulary 2개 export
+2. `src/lib/blog.ts` — category 타입 + helpers + validation
+3. 9편 MDX frontmatter 마이그레이션
+4. Build check (Day 1 끝)
+5. `/blog/category/[category]/page.tsx` 신규 route
+6. `CategoryPills` · `CategoryBadge` · `TagFilter` 3개 컴포넌트
+7. `PostCard` 에 CategoryBadge 통합
+8. `/blog/page.tsx` TagCloud → TagFilter 교체 + CategoryPills 추가
+9. `sitemap.ts` category URL 추가
+10. `/blog-new` 스킬 4개 파일 업데이트
+11. 전체 빌드 + Chrome MCP QA
+12. Gap 분석 + 반복 개선
+
+---
+
+## 6. 참조
+
+- Plan: `docs/01-plan/blog-categories-and-tooling.plan.md`
+- 기존 tag 파일: `apps/web/src/lib/tags.ts`
+- 기존 blog parser: `apps/web/src/lib/blog.ts`
+- 기존 tag route: `apps/web/src/app/blog/tag/[tag]/page.tsx` (참고 패턴)
+- Layout contract: `tene-biz/.claude/rules/blog-content.md §7.1`


### PR DESCRIPTION
## Summary

Three-commit change that reorganizes the blog around a **Category (1 required) + Tag (2–4) 2-layer taxonomy** and ships two new posts opening the Engineering and Philosophy categories.

### Commits

1. **b7e5482** — `feat(blog): introduce 2-layer taxonomy` — data layer, 9 existing-post migrations, JSON-LD.
2. **b034123** — `feat(blog): routes, UI, and landing` — 4 category hub pages, 5 new components (CategoryPills, CategoryBadge, TagFilter, BlogIndexClient, BlogPreview), PostCard/PostHero updates, sitemap, landing section. Plus plan + design docs.
3. **8c3448e** — `feat(blog): add engineering + philosophy posts` — `web-basics-for-vibe-coders` (engineering, ~2.5k w) and `ai-agents-and-human-responsibility` (philosophy, ~2.4k w).

### Why

Existing 10-tag vocabulary was product-centric — no place for web-concept pieces or AI-philosophy essays. New structure:

- **Categories (4)**: `tools`, `engineering`, `vibe-coding`, `philosophy` — primary navigation axis.
- **Tags (15)**: product (tene, bkit) · technical (security, cryptography, architecture, devsecops, cli) · AI-era (harness-engineering, workflow, claude-code, cursor) · format (tutorial, comparison, deep-dive, founder-story).

Distribution after this PR: tools 3 · engineering 2 · vibe-coding 5 · philosophy 1 — every category has content on day one.

### URLs preserved (SEO safe)

- All 9 existing `/blog/{slug}` canonicals unchanged.
- `/blog/tag/{tag}` routes still exist for the 15 active tags; the 2 retired tags (`ai`, `go`) stop being generated.
- **New**: `/blog/category/{tools|engineering|vibe-coding|philosophy}` (4) + `/blog?tags=a,b` filter on `/blog` index.

### Test plan

- [x] `npx next build` passes — 11 blog posts + 4 category pages SSG'd
- [x] `grep` BlogPosting + FAQPage schemas on all 11 posts
- [x] Retired `/blog/tag/ai`, `/blog/tag/go` confirmed removed
- [x] Sitemap.xml includes 4 new `/blog/category/*` URLs
- [x] Landing `<BlogPreview />` shows one post per category
- [ ] Vercel preview — manual eyeball after PR opens (filter interaction, mobile overflow)
- [ ] Staging production — spot check after merge

### Follow-ups (not in this PR)

- Chrome MCP was not connected during local QA — runtime filter UX verified only on Vercel preview.
- More content for the philosophy and engineering categories (planned in `docs/01-plan/blog-content-batch-2026-04-23.plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)