### PR TITLE
release: blog filter + articleSection fix

### DIFF
--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,9 +1,7 @@
-import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { InteractiveGrid } from "@/components/interactive-grid";
-import { PostCard } from "@/components/blog/post-card";
 import { RssLink } from "@/components/blog/rss-link";
 import { CategoryPills } from "@/components/blog/category-pills";
 import { TagFilter } from "@/components/blog/tag-filter";
@@ -103,14 +101,7 @@ export default function BlogIndex() {
 
         {tags.length > 0 && (
           <section className="px-4 pb-8 sm:px-6">
-            {/* useSearchParams suspense boundary (Next.js 15 requirement). */}
-            <Suspense
-              fallback={
-                <div className="mx-auto h-12 max-w-4xl rounded-lg border border-border/50 bg-surface/30" />
-              }
-            >
-              <TagFilter allTags={tags} />
-            </Suspense>
+            <TagFilter allTags={tags} />
           </section>
         )}
 
@@ -120,19 +111,7 @@ export default function BlogIndex() {
               No articles published yet. Check back soon.
             </div>
           ) : (
-            <Suspense
-              fallback={
-                <ul className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
-                  {postsForClient.map((post) => (
-                    <li key={post.slug}>
-                      <PostCard post={post} />
-                    </li>
-                  ))}
-                </ul>
-              }
-            >
-              <BlogIndexClient posts={postsForClient} />
-            </Suspense>
+            <BlogIndexClient posts={postsForClient} />
           )}
         </section>
       </main>

--- a/apps/web/src/components/blog/blog-index-client.tsx
+++ b/apps/web/src/components/blog/blog-index-client.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 // Client component that reads ?tags=a,b from the URL and filters the SSR'd
-// post list in-place. Renders the full list initially so users without JS
-// still see all articles. Kept separate from page.tsx to keep the server
-// component pure (no client hooks).
-import { useMemo } from "react";
-import { useSearchParams } from "next/navigation";
+// post list in place. Uses window.location.search rather than
+// next/navigation's useSearchParams — that hook combined with a Suspense
+// fallback in a statically-prerendered route was causing the initial render
+// to show the unfiltered fallback without ever swapping to the filtered
+// view. Reading directly from the URL after mount guarantees the filter
+// reflects whatever the browser actually loaded.
+import { useEffect, useMemo, useState } from "react";
 import { PostCard } from "@/components/blog/post-card";
 import type { BlogPostMeta } from "@/lib/blog";
 
@@ -13,7 +15,9 @@ type Props = {
   posts: BlogPostMeta[];
 };
 
-function parseSelected(raw: string | null): Set<string> {
+export const TAG_CHANGED_EVENT = "tene:blog-tags-changed";
+
+function parseSelected(raw: string | null | undefined): Set<string> {
   if (!raw) return new Set();
   return new Set(
     raw
@@ -23,18 +27,29 @@ function parseSelected(raw: string | null): Set<string> {
   );
 }
 
+function readTagsFromUrl(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  return parseSelected(new URLSearchParams(window.location.search).get("tags"));
+}
+
 export function BlogIndexClient({ posts }: Props) {
-  const searchParams = useSearchParams();
-  const selected = useMemo(
-    () => parseSelected(searchParams.get("tags")),
-    [searchParams],
-  );
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setSelected(readTagsFromUrl());
+    const sync = () => setSelected(readTagsFromUrl());
+    window.addEventListener("popstate", sync);
+    window.addEventListener(TAG_CHANGED_EVENT, sync);
+    return () => {
+      window.removeEventListener("popstate", sync);
+      window.removeEventListener(TAG_CHANGED_EVENT, sync);
+    };
+  }, []);
 
   const filtered = useMemo(() => {
     if (selected.size === 0) return posts;
-    // AND mode: a post matches only if it contains every selected tag.
     return posts.filter((p) =>
-      [...selected].every((t) => p.tags.includes(t as never)),
+      [...selected].every((t) => (p.tags as readonly string[]).includes(t)),
     );
   }, [posts, selected]);
 
@@ -57,7 +72,10 @@ export function BlogIndexClient({ posts }: Props) {
   }
 
   return (
-    <ul className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
+    <ul
+      className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2"
+      data-filter-active={selected.size > 0 ? "true" : "false"}
+    >
       {filtered.map((post) => (
         <li key={post.slug}>
           <PostCard post={post} />

--- a/apps/web/src/components/blog/tag-filter.tsx
+++ b/apps/web/src/components/blog/tag-filter.tsx
@@ -3,10 +3,18 @@
 // Instagram-style tag filter on /blog index. Client-only filtering via URL
 // query param (?tags=a,b). AND mode: a post is shown only if it carries
 // ALL selected tags. Collapsed by default to avoid clutter.
-import { useCallback, useMemo, useState, useTransition } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { getTagLabel, type TagKey } from "@/lib/tags";
+//
+// Uses window.location + history.replaceState directly rather than
+// next/navigation's router.replace + useSearchParams. The Next.js router
+// hooks combined with a statically-prerendered /blog route and a Suspense
+// fallback were causing the initial render on direct ?tags= URLs to keep
+// the Suspense fallback instead of hydrating the filtered view. Dispatching
+// a custom event on URL change lets BlogIndexClient stay in sync without
+// relying on the router subscription plumbing.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getTagLabel } from "@/lib/tags";
 import { track } from "@/lib/track";
+import { TAG_CHANGED_EVENT } from "@/components/blog/blog-index-client";
 
 type TagEntry = { tag: string; count: number };
 
@@ -15,7 +23,7 @@ type Props = {
   topN?: number; // how many to show before "Show all"
 };
 
-function parseTagsParam(raw: string | null): Set<string> {
+function parseTagsParam(raw: string | null | undefined): Set<string> {
   if (!raw) return new Set();
   return new Set(
     raw
@@ -25,18 +33,24 @@ function parseTagsParam(raw: string | null): Set<string> {
   );
 }
 
+function readFromUrl(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  return parseTagsParam(new URLSearchParams(window.location.search).get("tags"));
+}
+
 export function TagFilter({ allTags, topN = 6 }: Props) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [showAll, setShowAll] = useState(false);
-  const [, startTransition] = useTransition();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  const selected = useMemo(
-    () => parseTagsParam(searchParams.get("tags")),
-    [searchParams],
-  );
+  // Sync state with URL on mount and on browser nav events
+  useEffect(() => {
+    setSelected(readFromUrl());
+    const sync = () => setSelected(readFromUrl());
+    window.addEventListener("popstate", sync);
+    return () => window.removeEventListener("popstate", sync);
+  }, []);
 
   const filteredTags = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -49,26 +63,27 @@ export function TagFilter({ allTags, topN = 6 }: Props) {
   }, [allTags, search]);
 
   const visibleTags = useMemo(() => {
-    if (search.trim()) return filteredTags; // search overrides topN
+    if (search.trim()) return filteredTags;
     if (showAll) return filteredTags;
     return filteredTags.slice(0, topN);
   }, [filteredTags, showAll, search, topN]);
 
-  const updateUrl = useCallback(
-    (nextSelected: Set<string>) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (nextSelected.size === 0) {
-        params.delete("tags");
-      } else {
-        params.set("tags", [...nextSelected].sort().join(","));
-      }
-      const query = params.toString();
-      startTransition(() => {
-        router.replace(query ? `/blog?${query}` : "/blog", { scroll: false });
-      });
-    },
-    [router, searchParams],
-  );
+  const updateUrl = useCallback((nextSelected: Set<string>) => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (nextSelected.size === 0) {
+      params.delete("tags");
+    } else {
+      params.set("tags", [...nextSelected].sort().join(","));
+    }
+    const query = params.toString();
+    const url = query
+      ? `${window.location.pathname}?${query}`
+      : window.location.pathname;
+    window.history.replaceState(window.history.state, "", url);
+    // Notify BlogIndexClient (and any other subscriber) that tags changed.
+    window.dispatchEvent(new Event(TAG_CHANGED_EVENT));
+  }, []);
 
   const toggle = (tag: string) => {
     const next = new Set(selected);
@@ -79,11 +94,13 @@ export function TagFilter({ allTags, topN = 6 }: Props) {
       next.add(tag);
       track("blog_tag_filter", { tag, action: "add", from: "filter" });
     }
+    setSelected(next);
     updateUrl(next);
   };
 
   const clearAll = () => {
     track("blog_tag_filter", { action: "clear_all", from: "filter" });
+    setSelected(new Set());
     updateUrl(new Set());
   };
 

--- a/apps/web/src/components/seo/article-jsonld.tsx
+++ b/apps/web/src/components/seo/article-jsonld.tsx
@@ -1,7 +1,7 @@
 // Design Ref: blog-seo-enhancements §2.1 — BlogPosting + BreadcrumbList in a
 // single @graph. Adds articleSection (G4) and author.sameAs (G5) alongside
 // the breadcrumb trail (G1).
-import { getTagLabel } from "@/lib/tags";
+import { getCategoryLabel } from "@/lib/tags";
 import type { BlogPostMeta } from "@/lib/blog";
 
 type Props = {
@@ -10,7 +10,6 @@ type Props = {
 
 export function BlogPostingJsonLd({ meta }: Props) {
   const canonical = meta.canonicalUrl!;
-  const primaryTag = meta.tags[0];
 
   const ld = {
     "@context": "https://schema.org",
@@ -21,8 +20,10 @@ export function BlogPostingJsonLd({ meta }: Props) {
         description: meta.description,
         datePublished: meta.publishedAt,
         dateModified: meta.updatedAt ?? meta.publishedAt,
-        // G4 — articleSection uses the first tag's display label
-        ...(primaryTag ? { articleSection: getTagLabel(primaryTag) } : {}),
+        // G4 — articleSection maps to the post's category (taxonomy change
+        // 2026-04-24: previously used first tag; category is now the
+        // primary navigation axis and a better Schema.org match).
+        articleSection: getCategoryLabel(meta.category),
         author: {
           "@type": "Person",
           name: meta.author ?? "tomo-kay",


### PR DESCRIPTION
## Summary
Promote hotfix (PR #69) from staging to main.

- Fix URL-based tag filter (\`/blog?tags=...\`) actually applying to post list.
- Fix BlogPosting articleSection to use category label, not first tag.

Full scope in PR #69. No behavior change beyond those two.

## Test plan
- [x] staging CI passed (from #69 merge)
- [ ] main production deploy — verify filter + articleSection on tene.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)