### PR TITLE
release: TTS + blog fixes + release pipeline resilience

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -148,11 +148,28 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ needs.auto-tag.outputs.version }}
 
       - name: Update LATEST_VERSION (stable only)
-        if: "!contains(needs.auto-tag.outputs.version, '-rc')"
+        # Runs even when GoReleaser exited non-zero on a non-critical step
+        # (e.g. Homebrew formula push hitting 401 when the tap repo is
+        # absent). Safeguard: refuse to flip the pointer unless the
+        # darwin/arm64 tarball for this version actually exists on S3 —
+        # that single artifact proves the `blobs:` publishing stage
+        # completed and the install.sh chain is serviceable.
+        #
+        # Prior to 2026-04-24 this step did not have `if: always()` and
+        # three consecutive stable releases (v1.0.5, v1.0.6, v1.0.7)
+        # required a manual S3 hotfix because the step was skipped after
+        # the Homebrew step failed.
+        if: always() && !contains(needs.auto-tag.outputs.version, '-rc')
         run: |
           VERSION="${{ needs.auto-tag.outputs.version }}"
           VERSION="${VERSION#v}"
+          TARBALL="s3://${{ env.RELEASE_BUCKET }}/v${VERSION}/tene_${VERSION}_darwin_arm64.tar.gz"
+          if ! aws s3 ls "$TARBALL" > /dev/null 2>&1; then
+            echo "::error::Refusing to update LATEST_VERSION — $TARBALL not found on S3"
+            exit 1
+          fi
           echo "$VERSION" > /tmp/LATEST_VERSION
           aws s3 cp /tmp/LATEST_VERSION s3://${{ env.RELEASE_BUCKET }}/LATEST_VERSION \
             --content-type "text/plain" \
             --cache-control "max-age=60"
+          echo "::notice::LATEST_VERSION updated to ${VERSION}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,40 +86,58 @@ release:
   prerelease: auto
   name_template: "v{{.Version}}"
 
-# Homebrew tap — publishes Formula/tene.rb to tomo-kay/homebrew-tene on each
-# stable release. Users then run: brew install tomo-kay/tene/tene
-brews:
-  - name: tene
-    homepage: "https://tene.sh"
-    description: "Local-first encrypted secret manager CLI for AI-safe developer workflows"
-    license: "MIT"
-    repository:
-      owner: tomo-kay
-      name: homebrew-tene
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    commit_author:
-      name: goreleaserbot
-      email: bot@tene.sh
-    commit_msg_template: "chore(tap): bump tene to {{ .Tag }}"
-    skip_upload: auto
-    install: |
-      bin.install "tene"
-      bash_completion.install "completions/tene.bash" => "tene"
-      zsh_completion.install "completions/_tene"
-      fish_completion.install "completions/tene.fish"
-      man1.install "manpages/tene.1"
-    test: |
-      system "#{bin}/tene", "version"
-    caveats: |
-      Get started:
-        tene init
-
-      Documentation:
-        https://github.com/tomo-kay/tene#readme
-
-      For AI agents using this project:
-        https://tene.sh/llms.txt
+# Homebrew tap — currently disabled (2026-04-24).
+#
+# Publishing to a Homebrew tap requires:
+#   1. A public GitHub repo `tomo-kay/homebrew-tene` to exist.
+#   2. A fine-grained PAT with `Contents: Read/Write` on that repo,
+#      stored as the `HOMEBREW_TAP_GITHUB_TOKEN` secret on this repo
+#      (tomo-kay/tene).
+#
+# Neither is set up yet, and three consecutive stable releases
+# (v1.0.5, v1.0.6, v1.0.7) failed on this block with a 401 that
+# skipped the downstream `Update LATEST_VERSION` step and left
+# install.sh pointing at a stale version.
+#
+# To re-enable:
+#   1. gh repo create tomo-kay/homebrew-tene --public --license MIT --add-readme
+#   2. Create a fine-grained PAT (Contents: Read/Write on the tap repo),
+#      then: gh secret set HOMEBREW_TAP_GITHUB_TOKEN --repo tomo-kay/tene
+#   3. Uncomment the block below and keep `skip_upload: false` so stable
+#      releases always publish the formula.
+#
+# brews:
+#   - name: tene
+#     homepage: "https://tene.sh"
+#     description: "Local-first encrypted secret manager CLI for AI-safe developer workflows"
+#     license: "MIT"
+#     repository:
+#       owner: tomo-kay
+#       name: homebrew-tene
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     directory: Formula
+#     commit_author:
+#       name: goreleaserbot
+#       email: bot@tene.sh
+#     commit_msg_template: "chore(tap): bump tene to {{ .Tag }}"
+#     skip_upload: false
+#     install: |
+#       bin.install "tene"
+#       bash_completion.install "completions/tene.bash" => "tene"
+#       zsh_completion.install "completions/_tene"
+#       fish_completion.install "completions/tene.fish"
+#       man1.install "manpages/tene.1"
+#     test: |
+#       system "#{bin}/tene", "version"
+#     caveats: |
+#       Get started:
+#         tene init
+#
+#       Documentation:
+#         https://github.com/tomo-kay/tene#readme
+#
+#       For AI agents using this project:
+#         https://tene.sh/llms.txt
 
 # Docker images published to GitHub Container Registry (GHCR).
 # Multi-arch via docker_manifests below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,13 @@ and tene adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - `/vs/*` Schema.org `SoftwareApplication` node now conforms to spec.
+- `auto-tag.yml` workflow's `Update LATEST_VERSION` step now runs with
+  `if: always()` and a S3 tarball existence check. Previously a
+  non-critical GoReleaser failure (e.g. Homebrew formula publish)
+  would skip this step and leave `install.sh` users on a stale
+  version — v1.0.5, v1.0.6, and v1.0.7 each required a manual S3
+  hotfix before the next release.
+- Homebrew publishing disabled in `.goreleaser.yml` until the
+  `tomo-kay/homebrew-tene` tap repository and
+  `HOMEBREW_TAP_GITHUB_TOKEN` secret are set up. Re-enable
+  instructions are preserved inline as a comment block.

--- a/apps/web/content/blog/ai-agents-and-human-responsibility.mdx
+++ b/apps/web/content/blog/ai-agents-and-human-responsibility.mdx
@@ -229,7 +229,7 @@ subtler:
 
 A sketch of the 2030-ish shape:
 
-```
+```text
 Board          — AI governance, data policy, risk
   ↓
 C-level        — system architect, not resource allocator

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -96,9 +96,14 @@ export function useMDXComponents(
       </blockquote>
     ),
     // Inline code vs code block — rehype-shiki renders blocks with className.
+    // For fenced blocks without a language tag, shiki does not add a className,
+    // so we also detect "block-ness" by looking for a newline in the content.
+    // That prevents the inline-code chip styling (bg-surface pill) from being
+    // applied to multiline blocks and clashing with <pre>'s bg-surface-2.
     code: ({ children, className, ...props }) => {
-      if (!className) {
-        // Inline code
+      const text = typeof children === "string" ? children : "";
+      const isBlock = !!className || text.includes("\n");
+      if (!isBlock) {
         return (
           <code
             className="rounded bg-surface px-1.5 py-0.5 font-mono text-sm text-accent"
@@ -108,9 +113,11 @@ export function useMDXComponents(
           </code>
         );
       }
-      // Block code — shiki adds class like "language-bash shiki ..."
+      // Block code — shiki adds class like "language-bash shiki ..." for
+      // language-tagged blocks. For plaintext blocks the className is missing
+      // and we render a bare <code> so <pre>'s bg-surface-2 shows through.
       return (
-        <code className={className} {...props}>
+        <code className={className ?? ""} {...props}>
           {children}
         </code>
       );

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -137,3 +137,40 @@ pre.shiki .line,
 pre[class*="language-"] .line {
   background: transparent !important;
 }
+
+/* ─────────────────────────────────────────────
+ * TTS — article auto-scroll + active paragraph highlight.
+ * Design Ref: docs/02-design/features/blog-tts.design.md §6
+ *
+ * scroll-margin-top keeps scrollIntoView() from hiding the target
+ * behind the fixed nav (~56px) if we ever fall back to block:'start'.
+ * The active paragraph gets a subtle tint + accent-colored left border
+ * while being read.
+ * ───────────────────────────────────────────── */
+article p,
+article h2,
+article h3,
+article h4,
+article h5,
+article li,
+article blockquote {
+  scroll-margin-top: 80px;
+}
+
+/* Class selector (not data attribute) because Tailwind v4's data-*
+ * attribute cascade integration was unexpectedly swallowing
+ * padding/border-color/background overrides on element types that the
+ * framework's base layer already pre-styles (h2, p, li).
+ * Hard-coded accent hex (#00ff88 = --accent) so the rule remains in a
+ * simple cascade bucket rather than interacting with CSS variable /
+ * @property plumbing. */
+article .tts-active,
+article [data-tts-active="true"] {
+  background-color: rgba(0, 255, 136, 0.12) !important;
+  border-left-width: 3px !important;
+  border-left-style: solid !important;
+  border-left-color: #00ff88 !important;
+  padding-left: 0.75rem !important;
+  margin-left: -0.875rem;
+  border-radius: 0 2px 2px 0;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -133,6 +133,19 @@ pre[class*="language-"] code {
   min-width: 100%;
 }
 
+/* Defense-in-depth: any <code> directly inside a <pre> inside the article
+ * must inherit the <pre> background. Covers the plaintext fenced-block case
+ * where shiki adds no className on <code>, so the MDX `code` component
+ * falls back to bare rendering — but browser UA styles or a stray `bg-*`
+ * Tailwind utility elsewhere could still paint a mismatched tint. */
+article pre > code {
+  background-color: transparent !important;
+  background: transparent !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  color: inherit;
+}
+
 pre.shiki .line,
 pre[class*="language-"] .line {
   background: transparent !important;

--- a/apps/web/src/components/blog/post-hero.tsx
+++ b/apps/web/src/components/blog/post-hero.tsx
@@ -1,5 +1,6 @@
 import { TagChip } from "@/components/blog/tag-chip";
 import { CategoryBadge } from "@/components/blog/category-badge";
+import { TTSButton } from "@/components/blog/tts-button";
 import type { BlogPostMeta } from "@/lib/blog";
 
 type Props = {
@@ -46,6 +47,8 @@ export function PostHero({ meta }: Props) {
         <p className="mt-6 text-base text-muted leading-relaxed sm:text-lg">
           {meta.description}
         </p>
+
+        <TTSButton slug={meta.slug} readingMinutes={meta.readingMinutes} />
 
         {meta.tags.length > 0 && (
           <div className="mt-6 flex flex-wrap gap-2">

--- a/apps/web/src/components/blog/tts-button.tsx
+++ b/apps/web/src/components/blog/tts-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// Design Ref: docs/02-design/features/blog-tts.design.md §2.1
+// Entry button. Stays collapsed until clicked; first click mounts the
+// full TTSPlayer (which then immediately begins playback on the click's
+// user gesture). Keeps the bundle cost zero for readers who don't use
+// TTS and preserves the iOS Safari "gesture must be live" constraint.
+import { useState } from "react";
+import dynamic from "next/dynamic";
+
+const TTSPlayer = dynamic(
+  () =>
+    import("@/components/blog/tts-player").then((m) => ({
+      default: m.TTSPlayer,
+    })),
+  { ssr: false },
+);
+
+type Props = {
+  slug: string;
+  readingMinutes: number;
+};
+
+export function TTSButton({ slug, readingMinutes }: Props) {
+  const [mounted, setMounted] = useState(false);
+
+  if (mounted) {
+    return (
+      <TTSPlayer
+        slug={slug}
+        readingMinutes={readingMinutes}
+        onClose={() => setMounted(false)}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setMounted(true)}
+      aria-label="Listen to article"
+      className="mt-4 inline-flex items-center gap-2 rounded-md border border-border bg-surface/60 px-3 py-1.5 text-sm text-muted backdrop-blur-sm transition-colors hover:border-accent/40 hover:text-foreground"
+    >
+      <ListenIcon className="h-4 w-4" />
+      Listen
+    </button>
+  );
+}
+
+function ListenIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      {/* Headphones icon */}
+      <path d="M3 12a9 9 0 0 1 18 0" />
+      <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/blog/tts-controls.tsx
+++ b/apps/web/src/components/blog/tts-controls.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+// Design Ref: docs/02-design/features/blog-tts.design.md §2.3
+// Presentational TTS controls. Pure UI — no state, no side effects.
+// Parent (TTSPlayer) owns all state and passes callbacks.
+import type { TTSState } from "@/lib/tts/use-tts";
+
+type Props = {
+  state: TTSState;
+  progress: { current: number; total: number };
+  rate: number;
+  voices: SpeechSynthesisVoice[];
+  selectedVoiceURI: string | null;
+  onPlay: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  onRateChange: (rate: number) => void;
+  onVoiceChange: (voiceURI: string) => void;
+  onClose: () => void;
+};
+
+const RATE_OPTIONS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+export function TTSControls({
+  state,
+  progress,
+  rate,
+  voices,
+  selectedVoiceURI,
+  onPlay,
+  onPause,
+  onResume,
+  onStop,
+  onRateChange,
+  onVoiceChange,
+  onClose,
+}: Props) {
+  const handleMain = () => {
+    if (state === "playing") onPause();
+    else if (state === "paused") onResume();
+    else onPlay();
+  };
+
+  const mainLabel =
+    state === "playing" ? "Pause" : state === "paused" ? "Resume" : "Play";
+
+  const percent =
+    progress.total > 0
+      ? Math.min(100, Math.round((progress.current / progress.total) * 100))
+      : 0;
+
+  return (
+    <div className="mt-4 rounded-lg border border-border bg-surface/60 p-3 backdrop-blur-sm">
+      {/* Row 1: main control + progress */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleMain}
+          aria-label={mainLabel}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-accent/40 bg-accent/10 text-accent transition-colors hover:bg-accent/20"
+        >
+          {state === "playing" ? (
+            <PauseIcon className="h-4 w-4" />
+          ) : (
+            <PlayIcon className="h-4 w-4" />
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={onStop}
+          aria-label="Stop"
+          disabled={state === "idle"}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted transition-colors hover:border-accent/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <StopIcon className="h-4 w-4" />
+        </button>
+
+        <div className="flex-1">
+          <div className="h-1.5 w-full rounded-full bg-border/60">
+            <div
+              className="h-full rounded-full bg-accent transition-[width] duration-200"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <div className="mt-1 text-xs text-muted">
+            Chunk {progress.current + 1} / {progress.total} · {percent}%
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close player"
+          className="rounded-md px-2 py-1 text-xs text-muted hover:text-foreground"
+        >
+          Close
+        </button>
+      </div>
+
+      {/* Row 2: speed + voice */}
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+        <label className="inline-flex items-center gap-2 text-muted">
+          Speed
+          <select
+            value={rate}
+            onChange={(e) => onRateChange(parseFloat(e.target.value))}
+            className="rounded-md border border-border bg-background px-2 py-1 text-foreground focus:border-accent focus:outline-none"
+          >
+            {RATE_OPTIONS.map((r) => (
+              <option key={r} value={r}>
+                {r}x
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="inline-flex items-center gap-2 text-muted">
+          Voice
+          <select
+            value={selectedVoiceURI ?? ""}
+            onChange={(e) => onVoiceChange(e.target.value)}
+            disabled={voices.length === 0}
+            className="max-w-[220px] truncate rounded-md border border-border bg-background px-2 py-1 text-foreground focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {voices.length === 0 ? (
+              <option value="">Loading…</option>
+            ) : (
+              voices.map((v) => (
+                <option key={v.voiceURI} value={v.voiceURI}>
+                  {v.name} ({v.lang})
+                </option>
+              ))
+            )}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function PlayIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  );
+}
+
+function PauseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M6 5h4v14H6zM14 5h4v14h-4z" />
+    </svg>
+  );
+}
+
+function StopIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M6 6h12v12H6z" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/blog/tts-player.tsx
+++ b/apps/web/src/components/blog/tts-player.tsx
@@ -3,11 +3,15 @@
 // Design Ref: docs/02-design/features/blog-tts.design.md §2.2
 // Orchestrator: glues useTTS + useScrollSync + useVoices + prefs
 // together, owns the chunks ref and the analytics event emission.
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TTSControls } from "@/components/blog/tts-controls";
 import { extractChunks, type TTSChunk } from "@/lib/tts/chunks";
 import { loadPrefs, savePrefs } from "@/lib/tts/prefs";
-import { pickBestVoice, useVoices } from "@/lib/tts/voices";
+import {
+  getNaturalVoices,
+  pickBestVoice,
+  useVoices,
+} from "@/lib/tts/voices";
 import { useTTS } from "@/lib/tts/use-tts";
 import { useScrollSync } from "@/lib/tts/use-scroll-sync";
 import { track } from "@/lib/track";
@@ -21,7 +25,10 @@ type Props = {
 const ARTICLE_SELECTOR = "article.min-w-0";
 
 export function TTSPlayer({ slug, readingMinutes, onClose }: Props) {
-  const voices = useVoices();
+  const allVoices = useVoices();
+  // Curated natural voices only — 3M/3F target, excludes macOS novelty
+  // (Bells, Cellos, Zarvox, etc.) + compact/premium name duplicates.
+  const voices = useMemo(() => getNaturalVoices(allVoices, "en"), [allVoices]);
   const chunksRef = useRef<TTSChunk[] | null>(null);
   const [chunkCount, setChunkCount] = useState(0);
 
@@ -31,8 +38,9 @@ export function TTSPlayer({ slug, readingMinutes, onClose }: Props) {
   );
   const [rate, setRate] = useState<number>(initialPrefs.rate);
 
-  // Pick best voice from live voice list + saved preference
-  const voice = pickBestVoice(voices, selectedVoiceURI, "en");
+  // Pick best voice from full list (incl. legacy saved URI) + saved pref.
+  // pickBestVoice prefers the curated natural set for fresh selections.
+  const voice = pickBestVoice(allVoices, selectedVoiceURI, "en");
 
   // Once voices load and we haven't committed a selection yet, sync the
   // UI dropdown to the chosen voice.

--- a/apps/web/src/components/blog/tts-player.tsx
+++ b/apps/web/src/components/blog/tts-player.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+// Design Ref: docs/02-design/features/blog-tts.design.md §2.2
+// Orchestrator: glues useTTS + useScrollSync + useVoices + prefs
+// together, owns the chunks ref and the analytics event emission.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TTSControls } from "@/components/blog/tts-controls";
+import { extractChunks, type TTSChunk } from "@/lib/tts/chunks";
+import { loadPrefs, savePrefs } from "@/lib/tts/prefs";
+import { pickBestVoice, useVoices } from "@/lib/tts/voices";
+import { useTTS } from "@/lib/tts/use-tts";
+import { useScrollSync } from "@/lib/tts/use-scroll-sync";
+import { track } from "@/lib/track";
+
+type Props = {
+  slug: string;
+  readingMinutes: number;
+  onClose: () => void;
+};
+
+const ARTICLE_SELECTOR = "article.min-w-0";
+
+export function TTSPlayer({ slug, readingMinutes, onClose }: Props) {
+  const voices = useVoices();
+  const chunksRef = useRef<TTSChunk[] | null>(null);
+  const [chunkCount, setChunkCount] = useState(0);
+
+  const initialPrefs = loadPrefs();
+  const [selectedVoiceURI, setSelectedVoiceURI] = useState<string | null>(
+    initialPrefs.voiceURI,
+  );
+  const [rate, setRate] = useState<number>(initialPrefs.rate);
+
+  // Pick best voice from live voice list + saved preference
+  const voice = pickBestVoice(voices, selectedVoiceURI, "en");
+
+  // Once voices load and we haven't committed a selection yet, sync the
+  // UI dropdown to the chosen voice.
+  useEffect(() => {
+    if (!selectedVoiceURI && voice) {
+      setSelectedVoiceURI(voice.voiceURI);
+    }
+    // If saved URI no longer exists, fall back + persist the new choice
+    if (
+      selectedVoiceURI &&
+      voices.length > 0 &&
+      !voices.some((v) => v.voiceURI === selectedVoiceURI) &&
+      voice
+    ) {
+      setSelectedVoiceURI(voice.voiceURI);
+      savePrefs({ voiceURI: voice.voiceURI });
+    }
+  }, [voices, voice, selectedVoiceURI]);
+
+  // Extract chunks once on mount — the article DOM is available now
+  // because PostHero renders before the MDX body in the same tree.
+  useEffect(() => {
+    const articleEl =
+      typeof document !== "undefined"
+        ? (document.querySelector<HTMLElement>(ARTICLE_SELECTOR) ?? null)
+        : null;
+    if (!articleEl) {
+      chunksRef.current = [];
+      setChunkCount(0);
+      return;
+    }
+    const chunks = extractChunks(articleEl);
+    chunksRef.current = chunks;
+    setChunkCount(chunks.length);
+  }, []);
+
+  // Analytics helper — compute percentRead at call time.
+  const percentRead = useCallback(
+    (idx: number) => {
+      const total = chunksRef.current?.length ?? 0;
+      if (total === 0) return 0;
+      return Math.min(100, Math.round((idx / total) * 100));
+    },
+    [],
+  );
+
+  const ttsRef = useRef<ReturnType<typeof useTTS> | null>(null);
+
+  const tts = useTTS({
+    chunksRef,
+    voice,
+    rate,
+    onComplete: () => {
+      track("blog_tts_complete", { slug, readingMinutes });
+    },
+    onError: () => {
+      // Silent — onerror usually means the user cancelled mid-utterance.
+      // Non-interrupted errors are already filtered in useTTS.
+    },
+  });
+  ttsRef.current = tts;
+
+  useScrollSync({
+    chunksRef,
+    currentChunkIndex: tts.currentChunkIndex,
+    enabled: tts.state !== "idle",
+  });
+
+  const handlePlay = useCallback(() => {
+    tts.play();
+    track("blog_tts_play", {
+      slug,
+      readingMinutes,
+      voice: voice?.name,
+      rate,
+    });
+  }, [tts, slug, readingMinutes, voice, rate]);
+
+  const handlePause = useCallback(() => {
+    tts.pause();
+    track("blog_tts_pause", {
+      slug,
+      percentRead: percentRead(tts.currentChunkIndex),
+    });
+  }, [tts, slug, percentRead]);
+
+  const handleResume = useCallback(() => {
+    tts.resume();
+    track("blog_tts_resume", {
+      slug,
+      percentRead: percentRead(tts.currentChunkIndex),
+    });
+  }, [tts, slug, percentRead]);
+
+  const handleStop = useCallback(() => {
+    const pct = percentRead(tts.currentChunkIndex);
+    tts.stop();
+    track("blog_tts_stop", { slug, percentRead: pct });
+  }, [tts, slug, percentRead]);
+
+  const handleRateChange = useCallback(
+    (r: number) => {
+      setRate(r);
+      savePrefs({ rate: r });
+      track("blog_tts_rate_change", { slug, rate: r });
+    },
+    [slug],
+  );
+
+  const handleVoiceChange = useCallback(
+    (voiceURI: string) => {
+      setSelectedVoiceURI(voiceURI);
+      savePrefs({ voiceURI });
+      const v = voices.find((x) => x.voiceURI === voiceURI);
+      if (v) {
+        track("blog_tts_voice_change", { slug, voiceName: v.name });
+      }
+    },
+    [slug, voices],
+  );
+
+  const handleClose = useCallback(() => {
+    tts.stop();
+    onClose();
+  }, [tts, onClose]);
+
+  return (
+    <TTSControls
+      state={tts.state}
+      progress={{ current: tts.currentChunkIndex, total: chunkCount }}
+      rate={rate}
+      voices={voices}
+      selectedVoiceURI={selectedVoiceURI}
+      onPlay={handlePlay}
+      onPause={handlePause}
+      onResume={handleResume}
+      onStop={handleStop}
+      onRateChange={handleRateChange}
+      onVoiceChange={handleVoiceChange}
+      onClose={handleClose}
+    />
+  );
+}

--- a/apps/web/src/lib/track.ts
+++ b/apps/web/src/lib/track.ts
@@ -52,6 +52,19 @@ type EventMap = {
   blog_external_link: { slug: string; domain: string };
   blog_read_complete: { slug: string; readingMinutes: number };
   blog_share_click: { slug: string; channel: string };
+  // blog-tts — Web Speech API based article TTS player.
+  blog_tts_play: {
+    slug: string;
+    readingMinutes: number;
+    voice?: string;
+    rate?: number;
+  };
+  blog_tts_pause: { slug: string; percentRead: number };
+  blog_tts_resume: { slug: string; percentRead: number };
+  blog_tts_stop: { slug: string; percentRead: number };
+  blog_tts_complete: { slug: string; readingMinutes: number };
+  blog_tts_rate_change: { slug: string; rate: number };
+  blog_tts_voice_change: { slug: string; voiceName: string };
 };
 
 export function track<E extends keyof EventMap>(

--- a/apps/web/src/lib/tts/chunks.ts
+++ b/apps/web/src/lib/tts/chunks.ts
@@ -1,0 +1,67 @@
+// Design Ref: docs/02-design/features/blog-tts.design.md §4.1
+// Pure utilities for extracting speakable text chunks from the rendered
+// article DOM and splitting long text into ~160 char sentence-aligned
+// chunks (Chrome 15-second utterance cutoff workaround).
+
+export interface TTSChunk {
+  text: string;
+  blockIndex: number;
+  blockEl: HTMLElement;
+}
+
+/**
+ * Split long text into sentence-aligned chunks of ≤ maxLen characters.
+ * Workaround for the Chrome bug that silently stops audio on utterances
+ * longer than ~15 seconds (chromium #679437).
+ */
+export function chunkText(text: string, maxLen = 160): string[] {
+  const re = new RegExp(
+    `[\\s\\S]{1,${maxLen}}[.!?,](?=\\s|$)|[\\s\\S]{1,${maxLen}}`,
+    "g",
+  );
+  const matches = text.match(re);
+  return matches && matches.length > 0 ? matches : [text];
+}
+
+const BLOCK_SELECTOR = "p, h2, h3, h4, h5, li, blockquote";
+
+/**
+ * Extract TTS-readable chunks from the rendered article DOM.
+ * Each chunk carries a reference to its containing block element so the
+ * scroll-sync hook can call scrollIntoView() on paragraph transitions.
+ */
+export function extractChunks(articleEl: HTMLElement): TTSChunk[] {
+  const blocks = Array.from(
+    articleEl.querySelectorAll<HTMLElement>(BLOCK_SELECTOR),
+  )
+    // Skip block-level code (<pre> wraps the shiki output). Inline <code>
+    // inside a <p> stays — textContent will flatten it.
+    .filter((el) => !el.closest("pre"))
+    .filter((el) => !isEmpty(el));
+
+  const chunks: TTSChunk[] = [];
+  blocks.forEach((el, blockIndex) => {
+    const text = readableText(el);
+    if (!text) return;
+    for (const t of chunkText(text, 160)) {
+      chunks.push({ text: t, blockIndex, blockEl: el });
+    }
+  });
+  return chunks;
+}
+
+/**
+ * textContent minus the rehypeAutolinkHeadings anchor and any aria-hidden
+ * decorative children, with whitespace normalized.
+ */
+function readableText(el: HTMLElement): string {
+  const clone = el.cloneNode(true) as HTMLElement;
+  clone
+    .querySelectorAll('.heading-anchor, [aria-hidden="true"]')
+    .forEach((n) => n.remove());
+  return (clone.textContent ?? "").replace(/\s+/g, " ").trim();
+}
+
+function isEmpty(el: HTMLElement): boolean {
+  return !(el.textContent ?? "").trim();
+}

--- a/apps/web/src/lib/tts/prefs.ts
+++ b/apps/web/src/lib/tts/prefs.ts
@@ -1,0 +1,63 @@
+// Design Ref: docs/02-design/features/blog-tts.design.md §4.2
+// Namespaced, versioned localStorage wrapper for TTS preferences
+// (voice + rate). Falls back to in-memory storage when localStorage is
+// unavailable (Safari private mode throws QuotaExceededError).
+
+const STORAGE_KEY = "tene:blog-tts";
+const VERSION = 1;
+
+export interface TTSPrefs {
+  v: number;
+  voiceURI: string | null;
+  rate: number; // clamped [0.5, 2]
+}
+
+const DEFAULTS: TTSPrefs = { v: VERSION, voiceURI: null, rate: 1 };
+
+let memoryFallback: TTSPrefs | null = null;
+
+export function loadPrefs(): TTSPrefs {
+  if (typeof window === "undefined") return DEFAULTS;
+  if (memoryFallback) return memoryFallback;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    const parsed = JSON.parse(raw);
+    if (parsed?.v !== VERSION) return DEFAULTS;
+    return {
+      v: VERSION,
+      voiceURI:
+        typeof parsed.voiceURI === "string" || parsed.voiceURI === null
+          ? parsed.voiceURI
+          : null,
+      rate: clampRate(parsed.rate),
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function savePrefs(patch: Partial<Omit<TTSPrefs, "v">>): void {
+  if (typeof window === "undefined") return;
+  const current = loadPrefs();
+  const next: TTSPrefs = {
+    v: VERSION,
+    voiceURI:
+      patch.voiceURI !== undefined ? patch.voiceURI : current.voiceURI,
+    rate: patch.rate !== undefined ? clampRate(patch.rate) : current.rate,
+  };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    memoryFallback = null;
+  } catch {
+    // iOS Safari private mode / quota exceeded → in-memory fallback so
+    // preferences at least persist for the current page session.
+    memoryFallback = next;
+  }
+}
+
+export function clampRate(r: unknown): number {
+  const n = typeof r === "number" ? r : parseFloat(String(r));
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(Math.max(n, 0.5), 2);
+}

--- a/apps/web/src/lib/tts/use-scroll-sync.ts
+++ b/apps/web/src/lib/tts/use-scroll-sync.ts
@@ -1,0 +1,139 @@
+// Design Ref: docs/02-design/features/blog-tts.design.md §3.2
+// Auto-scroll the article so the currently-spoken paragraph stays in
+// view, toggle a visual highlight, and respect the user if they scroll
+// away manually (2.5 s cooldown before auto-scroll resumes).
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { TTSChunk } from "./chunks";
+
+export interface UseScrollSyncOptions {
+  chunksRef: React.RefObject<TTSChunk[] | null>;
+  currentChunkIndex: number;
+  enabled: boolean;
+}
+
+const USER_SCROLL_SUSPEND_MS = 2500;
+const PROGRAMMATIC_SCROLL_SETTLE_MS = 800;
+
+export function useScrollSync(options: UseScrollSyncOptions): void {
+  const { chunksRef, currentChunkIndex, enabled } = options;
+
+  const prevBlockIdxRef = useRef<number | null>(null);
+  const prevElRef = useRef<HTMLElement | null>(null);
+  const programmaticRef = useRef(false);
+  const userScrolledAtRef = useRef(0);
+
+  // Track user scrolls so auto-scroll doesn't fight the reader.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onScroll = () => {
+      if (programmaticRef.current) return;
+      userScrolledAtRef.current = Date.now();
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  // React to chunk changes: swap highlight class, scroll on paragraph
+  // transitions only (not on sentence transitions inside the same block).
+  useEffect(() => {
+    if (!enabled) return;
+    const chunks = chunksRef.current ?? [];
+    const chunk = chunks[currentChunkIndex];
+    if (!chunk) return;
+
+    // Swap highlight via inline styles. Inline + !important is the most
+    // reliable path on top of Tailwind v4's base layer; we also keep
+    // the data attribute + class for QA querySelector convenience.
+    if (prevElRef.current && prevElRef.current !== chunk.blockEl) {
+      stripHighlight(prevElRef.current);
+    }
+    chunk.blockEl.setAttribute("data-tts-active", "true");
+    chunk.blockEl.classList.add("tts-active");
+    // No transition — when we setProperty the destination values, some
+    // browsers were interpolating from the default state forever rather
+    // than settling. Applying values directly keeps the highlight crisp.
+    chunk.blockEl.style.setProperty(
+      "background-color",
+      "rgba(0, 255, 136, 0.12)",
+      "important",
+    );
+    chunk.blockEl.style.setProperty("border-left-width", "3px", "important");
+    chunk.blockEl.style.setProperty("border-left-style", "solid", "important");
+    chunk.blockEl.style.setProperty(
+      "border-left-color",
+      "#00ff88",
+      "important",
+    );
+    chunk.blockEl.style.setProperty("padding-left", "0.75rem", "important");
+    chunk.blockEl.style.setProperty("margin-left", "-0.875rem", "important");
+    chunk.blockEl.style.setProperty(
+      "border-radius",
+      "0 2px 2px 0",
+      "important",
+    );
+    prevElRef.current = chunk.blockEl;
+
+    // Scroll only when we cross a block boundary.
+    if (prevBlockIdxRef.current === chunk.blockIndex) return;
+    prevBlockIdxRef.current = chunk.blockIndex;
+
+    // Respect user scroll: if they interacted recently, skip the scroll
+    // for this block (highlight still updates so they can catch up).
+    if (Date.now() - userScrolledAtRef.current < USER_SCROLL_SUSPEND_MS) {
+      return;
+    }
+
+    const reduced =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    programmaticRef.current = true;
+    chunk.blockEl.scrollIntoView({
+      behavior: reduced ? "auto" : "smooth",
+      block: "center",
+    });
+    const t = window.setTimeout(() => {
+      programmaticRef.current = false;
+    }, PROGRAMMATIC_SCROLL_SETTLE_MS);
+    return () => {
+      window.clearTimeout(t);
+    };
+  }, [chunksRef, currentChunkIndex, enabled]);
+
+  // When disabled (stop/unmount), strip the highlight so the paragraph
+  // returns to its normal style.
+  useEffect(() => {
+    if (!enabled && prevElRef.current) {
+      stripHighlight(prevElRef.current);
+      prevElRef.current = null;
+      prevBlockIdxRef.current = null;
+    }
+  }, [enabled]);
+
+  // Final cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (prevElRef.current) {
+        stripHighlight(prevElRef.current);
+        prevElRef.current = null;
+      }
+    };
+  }, []);
+}
+
+/** Remove the TTS highlight data/class/inline-style from an element. */
+function stripHighlight(el: HTMLElement): void {
+  el.removeAttribute("data-tts-active");
+  el.classList.remove("tts-active");
+  el.style.removeProperty("background-color");
+  el.style.removeProperty("border-left-width");
+  el.style.removeProperty("border-left-style");
+  el.style.removeProperty("border-left-color");
+  el.style.removeProperty("padding-left");
+  el.style.removeProperty("margin-left");
+  el.style.removeProperty("border-radius");
+}

--- a/apps/web/src/lib/tts/use-tts.ts
+++ b/apps/web/src/lib/tts/use-tts.ts
@@ -1,0 +1,164 @@
+// Design Ref: docs/02-design/features/blog-tts.design.md §3.1
+// Speech-synthesis playback lifecycle hook. Owns the utterance queue,
+// state transitions (idle/playing/paused), and browser quirk
+// mitigations (Chrome 15-sec chunking, cancel-emits-error filter,
+// visibility-based auto-pause, iOS gesture preservation).
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TTSChunk } from "./chunks";
+import { clampRate } from "./prefs";
+
+export type TTSState = "idle" | "playing" | "paused";
+
+export interface UseTTSOptions {
+  chunksRef: React.RefObject<TTSChunk[] | null>;
+  voice: SpeechSynthesisVoice | null;
+  rate: number;
+  onChunkChange?: (index: number) => void;
+  onComplete?: () => void;
+  onError?: (err: SpeechSynthesisErrorEvent) => void;
+}
+
+export interface UseTTSReturn {
+  state: TTSState;
+  currentChunkIndex: number;
+  play: () => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+}
+
+export function useTTS(options: UseTTSOptions): UseTTSReturn {
+  const { chunksRef, voice, rate, onChunkChange, onComplete, onError } =
+    options;
+
+  const [state, setState] = useState<TTSState>("idle");
+  const [currentChunkIndex, setCurrentChunkIndex] = useState(0);
+  const indexRef = useRef(0);
+
+  // Keep latest voice/rate in refs — utterance factory needs them at
+  // speak time without triggering re-render.
+  const voiceRef = useRef(voice);
+  const rateRef = useRef(rate);
+  useEffect(() => {
+    voiceRef.current = voice;
+  }, [voice]);
+  useEffect(() => {
+    rateRef.current = rate;
+  }, [rate]);
+
+  const onChunkChangeRef = useRef(onChunkChange);
+  const onCompleteRef = useRef(onComplete);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onChunkChangeRef.current = onChunkChange;
+    onCompleteRef.current = onComplete;
+    onErrorRef.current = onError;
+  });
+
+  const isTTSAvailable = (): boolean =>
+    typeof window !== "undefined" && "speechSynthesis" in window;
+
+  const speakNext = useCallback(() => {
+    if (!isTTSAvailable()) return;
+    const chunks = chunksRef.current ?? [];
+    const idx = indexRef.current;
+    const chunk = chunks[idx];
+    if (!chunk) {
+      setState("idle");
+      setCurrentChunkIndex(0);
+      onCompleteRef.current?.();
+      return;
+    }
+    const u = new SpeechSynthesisUtterance(chunk.text);
+    u.voice = voiceRef.current;
+    u.lang = voiceRef.current?.lang ?? "en-US";
+    u.rate = clampRate(rateRef.current);
+    u.onstart = () => {
+      setCurrentChunkIndex(idx);
+      onChunkChangeRef.current?.(idx);
+    };
+    u.onend = () => {
+      indexRef.current = idx + 1;
+      speakNext();
+    };
+    u.onerror = (e) => {
+      // Chrome emits 'interrupted' / 'canceled' on normal cancel().
+      // Treat as non-error; otherwise propagate.
+      if (e.error !== "interrupted" && e.error !== "canceled") {
+        onErrorRef.current?.(e);
+      }
+    };
+    window.speechSynthesis.speak(u);
+  }, [chunksRef]);
+
+  const play = useCallback(() => {
+    // Must be called synchronously inside a user-gesture handler on iOS
+    // Safari. Don't await anything here — keep the gesture "live".
+    if (!isTTSAvailable()) return;
+    const chunks = chunksRef.current ?? [];
+    if (chunks.length === 0) return;
+    window.speechSynthesis.cancel();
+    indexRef.current = 0;
+    setCurrentChunkIndex(0);
+    setState("playing");
+    speakNext();
+  }, [chunksRef, speakNext]);
+
+  const pause = useCallback(() => {
+    if (!isTTSAvailable()) return;
+    window.speechSynthesis.pause();
+    setState("paused");
+  }, []);
+
+  const resume = useCallback(() => {
+    if (!isTTSAvailable()) return;
+    window.speechSynthesis.resume();
+    setState("playing");
+  }, []);
+
+  const stop = useCallback(() => {
+    if (!isTTSAvailable()) return;
+    window.speechSynthesis.cancel();
+    indexRef.current = 0;
+    setCurrentChunkIndex(0);
+    setState("idle");
+  }, []);
+
+  // Unmount cleanup — always cancel so the voice doesn't bleed into
+  // the next route (Next.js client navigation preserves window but
+  // unmounts the component tree).
+  useEffect(() => {
+    return () => {
+      if (isTTSAvailable()) {
+        window.speechSynthesis.cancel();
+      }
+    };
+  }, []);
+
+  // Background tab handling — pause when the tab is hidden, resume when
+  // it becomes visible again, but only if the user didn't manually pause.
+  const pausedByVisibilityRef = useRef(false);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisibility = () => {
+      if (!isTTSAvailable()) return;
+      if (document.hidden && state === "playing") {
+        window.speechSynthesis.pause();
+        pausedByVisibilityRef.current = true;
+        setState("paused");
+      } else if (!document.hidden && pausedByVisibilityRef.current) {
+        window.speechSynthesis.resume();
+        pausedByVisibilityRef.current = false;
+        setState("playing");
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [state]);
+
+  return { state, currentChunkIndex, play, pause, resume, stop };
+}

--- a/apps/web/src/lib/tts/voices.ts
+++ b/apps/web/src/lib/tts/voices.ts
@@ -2,9 +2,66 @@
 // Voice enumeration + selection. Chrome returns [] on first getVoices()
 // call and populates asynchronously (fires 'voiceschanged'); Safari
 // returns them synchronously. This hook subscribes to both paths.
+//
+// Voice curation (2026-04-24): raw `speechSynthesis.getVoices()` on
+// macOS returns ~210 entries including legacy novelty voices — Bells,
+// Bubbles, Zarvox, Bad News, Whisper, Cellos, etc. — that play actual
+// sound effects instead of natural speech, plus compact/premium
+// duplicates of the same name. We filter via a human-curated allowlist
+// (NATURAL_VOICE_ALLOWLIST) to show only ~6-10 natural voices across
+// 3 male / 3 female tones.
 "use client";
 
 import { useEffect, useState } from "react";
+
+/**
+ * Known-natural voice names across macOS / Windows / Chrome / Edge / Linux.
+ * If a user's OS exposes none of these, we fall back to the lang-prefix
+ * filter so the dropdown is never empty.
+ */
+/**
+ * Tight allowlist targeting ~3 male + ~3 female natural voices per
+ * platform. We intentionally keep this short: more options is more
+ * choice paralysis, and the novelty/compact noise in the raw
+ * getVoices() list is what we're trying to eliminate. If a user
+ * really wants an obscure voice, they can still pick it from their
+ * OS's native TTS settings and install tene elsewhere.
+ */
+const NATURAL_VOICE_ALLOWLIST: ReadonlySet<string> = new Set([
+  // macOS female — 3 distinct accents
+  "Samantha", // en-US, F (Apple flagship, decades of tuning)
+  "Karen", // en-AU, F
+  "Moira", // en-IE, F
+  // macOS male — 3 distinct accents
+  "Alex", // en-US, M (Apple flagship, if installed)
+  "Daniel", // en-GB, M
+  "Aaron", // en-US, M (fallback if Alex missing)
+  // Chrome / Edge cloud voices — cross-platform fallbacks for users
+  // whose OS exposes none of the above (Windows, Linux, ChromeOS).
+  "Google US English",
+  "Google UK English Female",
+  "Google UK English Male",
+  "Microsoft Aria Online (Natural) - English (United States)",
+  "Microsoft Guy Online (Natural) - English (United States)",
+]);
+
+/**
+ * macOS new-naming adds a locale suffix — "Daniel (English (UK))" or
+ * "Daniel (영어(영국))" depending on the OS language — to the
+ * otherwise-same voice. Strip everything from the first " (" so the
+ * allowlist match still works.
+ */
+function voiceBaseName(name: string): string {
+  const idx = name.indexOf(" (");
+  return idx > 0 ? name.slice(0, idx).trim() : name.trim();
+}
+
+export function isNaturalVoice(voice: SpeechSynthesisVoice): boolean {
+  return (
+    NATURAL_VOICE_ALLOWLIST.has(voice.name) ||
+    NATURAL_VOICE_ALLOWLIST.has(voiceBaseName(voice.name))
+  );
+}
 
 export function useVoices(): SpeechSynthesisVoice[] {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
@@ -37,13 +94,61 @@ export function filterByLangPrefix(
 }
 
 /**
+ * The UI-facing voice list: lang-filtered, de-duplicated by voice
+ * display name, and cut to the allowlist. If the filter leaves us
+ * with fewer than 2 voices (exotic OS), falls back to all lang-matching
+ * voices minus the well-known novelty names.
+ */
+const NOVELTY_BLOCKLIST: ReadonlySet<string> = new Set([
+  "Albert", "Bad News", "Bahh", "Bells", "Boing", "Bubbles", "Cellos",
+  "Deranged", "Good News", "Hysterical", "Jester", "Junior", "Kathy",
+  "Organ", "Pipe Organ", "Princess", "Ralph", "Shelley", "Superstar",
+  "Trinoids", "Whisper", "Wobble", "Zarvox", "Grandma", "Grandpa",
+]);
+
+export function getNaturalVoices(
+  voices: SpeechSynthesisVoice[],
+  langPrefix = "en",
+): SpeechSynthesisVoice[] {
+  const langMatches = filterByLangPrefix(voices, langPrefix);
+  const curated = langMatches.filter(isNaturalVoice);
+  if (curated.length >= 2) return dedupByBaseName(curated);
+  // Fallback: return everything lang-matching minus confirmed novelty
+  const safeFallback = langMatches.filter(
+    (v) => !NOVELTY_BLOCKLIST.has(voiceBaseName(v.name)),
+  );
+  return dedupByBaseName(safeFallback);
+}
+
+/**
+ * macOS exposes Compact + Premium variants of the same voice with
+ * identical display names. Keep only the first occurrence so the
+ * dropdown doesn't have "Samantha" three times.
+ */
+function dedupByBaseName(
+  voices: SpeechSynthesisVoice[],
+): SpeechSynthesisVoice[] {
+  const seen = new Set<string>();
+  const out: SpeechSynthesisVoice[] = [];
+  for (const v of voices) {
+    const key = voiceBaseName(v.name) + "|" + v.lang;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(v);
+  }
+  return out;
+}
+
+/**
  * Pick the best voice given the saved voiceURI + the live voice list.
  * Fallback chain:
- *   1. Saved URI exists in current list                 → use it
- *   2. A default voice in the target language prefix    → use it
- *   3. First voice matching the language prefix         → use it
- *   4. First voice overall                              → use it
- *   5. null (let the browser pick its own default)
+ *   1. Saved URI exists in the curated natural set        → use it
+ *   2. Saved URI exists in the full voice list (legacy)   → use it
+ *   3. First natural voice matching the language prefix   → use it
+ *   4. Default voice in the language prefix               → use it
+ *   5. First voice matching the language prefix           → use it
+ *   6. First voice overall                                → use it
+ *   7. null (let the browser pick its own default)
  */
 export function pickBestVoice(
   all: SpeechSynthesisVoice[],
@@ -51,11 +156,14 @@ export function pickBestVoice(
   langPrefix = "en",
 ): SpeechSynthesisVoice | null {
   if (!all.length) return null;
-  const matches = filterByLangPrefix(all, langPrefix);
+  const natural = getNaturalVoices(all, langPrefix);
+  const langMatches = filterByLangPrefix(all, langPrefix);
   return (
-    (savedURI && matches.find((v) => v.voiceURI === savedURI)) ||
-    matches.find((v) => v.default) ||
-    matches[0] ||
+    (savedURI && natural.find((v) => v.voiceURI === savedURI)) ||
+    (savedURI && all.find((v) => v.voiceURI === savedURI)) ||
+    natural[0] ||
+    langMatches.find((v) => v.default) ||
+    langMatches[0] ||
     all[0] ||
     null
   );

--- a/apps/web/src/lib/tts/voices.ts
+++ b/apps/web/src/lib/tts/voices.ts
@@ -1,0 +1,62 @@
+// Design Ref: docs/02-design/features/blog-tts.design.md §4.3
+// Voice enumeration + selection. Chrome returns [] on first getVoices()
+// call and populates asynchronously (fires 'voiceschanged'); Safari
+// returns them synchronously. This hook subscribes to both paths.
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useVoices(): SpeechSynthesisVoice[] {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+      return;
+    }
+    const update = () => setVoices(window.speechSynthesis.getVoices());
+    update();
+    window.speechSynthesis.addEventListener("voiceschanged", update);
+    return () => {
+      window.speechSynthesis.removeEventListener("voiceschanged", update);
+    };
+  }, []);
+
+  return voices;
+}
+
+/**
+ * Filter to voices whose BCP-47 language tag starts with `prefix`.
+ * e.g. filterByLangPrefix(voices, 'en') matches en-US, en-GB, en-AU.
+ */
+export function filterByLangPrefix(
+  voices: SpeechSynthesisVoice[],
+  prefix: string,
+): SpeechSynthesisVoice[] {
+  const p = prefix.toLowerCase();
+  return voices.filter((v) => v.lang.toLowerCase().startsWith(p));
+}
+
+/**
+ * Pick the best voice given the saved voiceURI + the live voice list.
+ * Fallback chain:
+ *   1. Saved URI exists in current list                 → use it
+ *   2. A default voice in the target language prefix    → use it
+ *   3. First voice matching the language prefix         → use it
+ *   4. First voice overall                              → use it
+ *   5. null (let the browser pick its own default)
+ */
+export function pickBestVoice(
+  all: SpeechSynthesisVoice[],
+  savedURI: string | null,
+  langPrefix = "en",
+): SpeechSynthesisVoice | null {
+  if (!all.length) return null;
+  const matches = filterByLangPrefix(all, langPrefix);
+  return (
+    (savedURI && matches.find((v) => v.voiceURI === savedURI)) ||
+    matches.find((v) => v.default) ||
+    matches[0] ||
+    all[0] ||
+    null
+  );
+}

--- a/docs/01-plan/blog-tts.plan.md
+++ b/docs/01-plan/blog-tts.plan.md
@@ -1,0 +1,349 @@
+# Blog TTS — Plan
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `blog-tts` (블로그 글 음성 재생 기능) |
+| 기반 리서치 | 2026-04-24 /pdca team 병렬 조사 (ttsreader + tene/apps/web) |
+| 브랜치 | `feature/blog-tts` (origin/staging 베이스) |
+| 후속 | design → do → QA → report |
+| 총 공수 | ~6-8 인시간 (MVP 기준) |
+
+---
+
+## 1. 목적 (Why)
+
+**가설**: 블로그 글이 길어지고 있음 (최근 2편 각 ~2,500 단어, 10-11분 read). 이동 중/멀티태스킹 중 **귀로 듣는 옵션**이 있으면 retention + engagement 상승. 특히 `philosophy` 카테고리 에세이성 글은 audio-first 소비에 적합.
+
+**제약 (사용자 확정)**: **비용 0**. 외부 TTS API (OpenAI/ElevenLabs/Google Cloud)를 쓰지 않음. 브라우저 내장 **Web Speech API** 로만 구현.
+
+**영감 source**: [ttsreader.com](https://ttsreader.com) + [RonenR/ttsreader](https://github.com/RonenR/ttsreader) 엔진 — 같은 Web Speech API 패턴 사용.
+
+## 2. 기술 선택 근거
+
+### 2.1 Web Speech API 를 택한 이유
+
+`window.speechSynthesis` + `SpeechSynthesisUtterance` — 모든 주요 브라우저 내장:
+
+- ✅ **Zero cost** — API 키/서버/스토리지 전혀 없음
+- ✅ **Zero backend** — Next.js 정적 빌드 그대로 OK
+- ✅ **Offline voices** — macOS/Windows/Android 시스템 보이스 사용
+- ✅ **MIT-level 자유도** — 표준 웹 API, 종속성 없음
+- ⚠️ **품질 편차** — OS/브라우저마다 voice quality 상이
+- ⚠️ **Chrome 15초 버그** — 단일 utterance가 15초 후 끊김. 문장 단위 chunking 필요
+- ⚠️ **iOS 제스처 제약** — 첫 `speak()`는 user-gesture 핸들러 내에서 동기 호출 필요
+- ⚠️ **Firefox boundary 이벤트 불안정** — 단어 하이라이트는 cross-browser 불가. 문장 하이라이트로 폴백
+
+### 2.2 대안 비교 (검토 후 기각)
+
+| 대안 | 품질 | 비용 | 기각 사유 |
+|---|:-:|---|---|
+| OpenAI TTS (pre-generated) | ⭐⭐⭐⭐⭐ | 편당 ~$0.15 | 사용자가 비용 0 요구 |
+| ElevenLabs pre-gen | ⭐⭐⭐⭐⭐ | ~$0.30/편 | 동일 이유 |
+| Google Cloud TTS | ⭐⭐⭐⭐ | pay-per-char | 동일 이유 |
+| ttsreader 엔진 (RonenR/ttsreader lib) 직접 import | ⭐⭐⭐ | 0 | 라이선스 명시 불분명(LICENSE 파일 미확인) + Next.js 타입 정합성 저하 → **패턴만 차용** |
+| **Web Speech API 직접 구현** | ⭐⭐⭐ | **0** | ✅ **선택** |
+
+### 2.3 ttsreader 엔진에서 배운 핵심 패턴 (인용하되 직접 import 안 함)
+
+1. **문장 단위 chunking** — 정규표현식 `[\s\S]{1,160}[.!?,](?=\s|$)|[\s\S]{1,160}` 로 ~160자 단위로 자름. Chrome 15초 버그 우회.
+2. **순차 재생 큐** — 각 chunk의 `utterance.onend` 에서 다음 chunk `speak()` 호출.
+3. **Voice filtering by language prefix** — `v.lang.startsWith('en')` 로 필터링.
+4. **iOS 호환 제스처 유지** — 클릭 핸들러 내부에서 비동기 없이 `speechSynthesis.speak()` 호출.
+5. **Rate clamp** — Chrome 한계 때문에 `[0.5, 2.0]` 범위로 제한.
+
+## 3. 스코프
+
+### 3.1 MVP 포함
+
+| # | 항목 | 설명 |
+|:-:|---|---|
+| M1 | **Listen 버튼** | `PostHero` 하단 — 설명 다음 줄에 "Listen" 버튼 추가 |
+| M2 | **TTS player 컴포넌트** | `<TTSPlayer>` client component — play/pause/stop/speed slider(0.5-2x)/voice dropdown |
+| M3 | **문장 chunking + 순차 재생** | Chrome 15초 버그 회피. 160자 단위로 자르고 큐 처리 |
+| M4 | **Voice selection** | `getVoices()` 에서 en-* 로 시작하는 보이스 필터링, 사용자 선택 dropdown |
+| **M4b** | **Voice persistence (localStorage)** | 선택한 voice + rate 를 `localStorage` 에 저장. 다음 방문/다음 글에서 같은 선택 유지. 키 namespace: `tene:blog-tts:{voice,rate}` |
+| M5 | **Code block skip** | MDX `<pre>` / `<code>` 블록은 읽지 않음. 텍스트 추출 시 제외 + 스크롤 sync 시에도 건너뜀 |
+| M6 | **Progress indicator** | 현재 chunk 번호 / 총 chunk 수 표시 |
+| **M6b** | **Auto-scroll sync (paragraph-level)** | TTS 가 현재 읽는 문단(`<p>`/`<h2>`/`<li>`)을 `scrollIntoView({behavior:'smooth', block:'center'})` 로 화면 중앙에 배치 + 시각 하이라이트 CSS 클래스 토글. 코드블록은 skip이므로 다음 문단으로 건너뜀. 사용자 스크롤 개입 감지 시 auto-scroll 일시정지 |
+| M7 | **Analytics events** | `blog_tts_play`, `blog_tts_pause`, `blog_tts_complete`, `blog_tts_rate_change`, `blog_tts_voice_change` 등록 + 발사 |
+| M8 | **Unload cleanup** | 페이지 이탈 시 `speechSynthesis.cancel()` — 다음 페이지에서 이전 글 음성이 남는 현상 방지 |
+
+### 3.2 MVP 미포함 (후속 phase B)
+
+- ❌ **단어 레벨 하이라이트** (`boundary` 이벤트 기반) — Firefox/Android 지원 불안정. 복잡도 큼. 문단 레벨(M6b)로 충분히 follow-along UX 제공
+- ❌ **재생 위치 저장 (seek/resume)** — 첫 릴리스 후 사용자 피드백 보고 판단
+- ❌ **다국어 자동 감지** — 현재 모든 글이 `en-US`. 한국어 글 추가 시 재검토
+- ❌ **키보드 단축키** (Space, Esc) — a11y 개선 사이클에서
+- ❌ **모바일 floating mini-player** — MVP는 단일 Listen 버튼
+
+### 3.3 미포함 (의도적 제외)
+
+- 외부 TTS API 연동 — 비용 제약으로 완전 배제
+- 빌드 타임 mp3 pre-generation — 동일 이유
+- 오디오 파일 다운로드 — 사용자 요구 없음
+
+## 4. 설계 결정 요약 (Design phase 에서 상세화 예정)
+
+### 4.1 Integration point
+
+리서치 결과 4개 후보 중 **#1 (PostHero 하단 Listen 버튼)** 채택:
+
+- 발견성 최고: 글 상단 fold 안에 보임
+- 모바일+데스크톱 커버
+- 공수 최저 — PostHero 수정 1곳 + 신규 컴포넌트 1개
+- 리스크 최저 — 기존 레이아웃 계약 (`max-w-3xl`, `pt-4`, 블로그 §7.1) 불변
+
+### 4.2 Component split
+
+```
+<PostHero>  (server component)
+  └─ <TTSButton>  (client component, "Listen" 버튼 트리거)
+         ↓ 클릭 시 mount
+      <TTSPlayer>  (client component, 실제 재생 로직)
+```
+
+글 상세 DOM 에서 텍스트 추출은 `<article className="min-w-0">` 컨테이너(page.tsx:129)를 query selector로 잡음. `<pre>` 자식은 제외.
+
+### 4.3 Text extraction + chunk↔DOM mapping strategy
+
+**Chunking이 DOM 블록과 맞물려야 scroll sync 가능**:
+
+```ts
+interface TTSChunk {
+  text: string;          // 실제 읽을 160자 이내 문장 단위
+  blockEl: HTMLElement;  // 속한 <p>/<h2>/<h3>/<li>
+  blockIndex: number;    // 전체 블록 순번 (scroll-into-view 대상)
+}
+
+function extractChunks(articleEl: HTMLElement): TTSChunk[] {
+  const blocks = articleEl.querySelectorAll('p, h2, h3, h4, li, blockquote');
+  const chunks: TTSChunk[] = [];
+  let blockIndex = 0;
+  for (const blockEl of blocks) {
+    // 코드블록 포함 요소는 skip
+    if (blockEl.querySelector('pre, code')) continue;
+    const text = blockEl.textContent?.trim() ?? '';
+    if (!text) continue;
+    const sentences = chunkText(text, 160);  // 기존 chunking 함수
+    for (const s of sentences) {
+      chunks.push({ text: s, blockEl: blockEl as HTMLElement, blockIndex });
+    }
+    blockIndex++;
+  }
+  return chunks;
+}
+```
+
+### 4.4 Scroll sync 전략
+
+**접근**: 문단 단위. chunk 의 onstart 에서 `blockEl.scrollIntoView({behavior:'smooth', block:'center'})`.
+
+**사용자 스크롤 개입 감지**:
+- user-initiated scroll (wheel, touch, keyboard arrow) 감지 → auto-scroll 2초 suspend
+- 2초 내 재개입 없으면 재개
+- 구현: `scroll` 이벤트 listener + debounced flag
+
+**블록 전환 감지**:
+- 각 utterance 의 `onstart` 이벤트에서 `chunk.blockIndex` 가 직전 chunk 와 다를 때만 scroll 실행
+- 같은 문단 내 여러 chunk 가 연속이면 scroll 1회만
+
+**시각 하이라이트**:
+```css
+.tts-active-block {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-left: 2px solid var(--accent);
+  padding-left: 1rem;
+  margin-left: -1.125rem;  /* 기존 position 유지 */
+  transition: background 200ms ease;
+}
+```
+
+### 4.5 Voice/Rate 지속성 (M4b)
+
+```ts
+const STORAGE_KEYS = {
+  voice: 'tene:blog-tts:voice',  // voiceURI 저장
+  rate: 'tene:blog-tts:rate',     // string ("1.25") 저장
+} as const;
+
+function loadPrefs() {
+  if (typeof window === 'undefined') return { voiceURI: null, rate: 1 };
+  return {
+    voiceURI: localStorage.getItem(STORAGE_KEYS.voice),
+    rate: parseFloat(localStorage.getItem(STORAGE_KEYS.rate) ?? '1') || 1,
+  };
+}
+
+function savePrefs({ voiceURI, rate }: { voiceURI?: string; rate?: number }) {
+  if (typeof window === 'undefined') return;
+  if (voiceURI) localStorage.setItem(STORAGE_KEYS.voice, voiceURI);
+  if (rate != null) localStorage.setItem(STORAGE_KEYS.rate, String(rate));
+}
+```
+
+**기본값 선정 로직**:
+1. `localStorage` 에 저장된 `voiceURI` 가 있고 현재 `getVoices()` 결과에도 존재 → 그것 사용
+2. 없으면 `en-*` 보이스 중 첫 번째
+3. 그것도 없으면 `null` (browser default)
+
+### 4.4 Utterance chunking
+
+```ts
+function chunkText(text: string, max = 160): string[] {
+  const re = new RegExp(`[\\s\\S]{1,${max}}[.!?,](?=\\s|$)|[\\s\\S]{1,${max}}`, 'g');
+  return text.match(re) ?? [text];
+}
+```
+
+~160자 chunk. 2,500단어 글 기준 약 80-100개 chunk. Chunk당 평균 12-15초 재생 → Chrome 버그 회피.
+
+### 4.6 Analytics event 설계
+
+`src/lib/track.ts` EventMap 확장:
+```ts
+blog_tts_play:          { slug: string; readingMinutes: number };
+blog_tts_pause:         { slug: string; percentRead: number };
+blog_tts_resume:        { slug: string; percentRead: number };
+blog_tts_complete:      { slug: string; readingMinutes: number };
+blog_tts_rate_change:   { slug: string; rate: number };
+blog_tts_voice_change:  { slug: string; voiceName: string };
+```
+
+## 5. 성공 기준
+
+### 5.1 Functional
+
+- [ ] macOS Safari/Chrome/Firefox 에서 11편 모두 재생됨 (맨 앞 30초 + 맨 뒤 30초 샘플)
+- [ ] 재생 중 Pause → Resume 정상 동작
+- [ ] Stop 시 state 초기화
+- [ ] Speed 0.75x/1x/1.25x/1.5x 전환 실시간 반영
+- [ ] Voice dropdown에 최소 1개 이상 en-* voice 노출
+- [ ] **Voice 선택 후 재방문 시 동일 voice 자동 선택됨** (localStorage)
+- [ ] **Rate 선택 후 재방문 시 동일 rate 자동 선택됨** (localStorage)
+- [ ] **현재 읽는 문단이 smooth scroll 로 화면 중앙 배치됨** (M6b)
+- [ ] **현재 문단에 시각적 하이라이트 (`.tts-active-block`) 적용됨**
+- [ ] **사용자 수동 scroll 시 auto-scroll 2초간 suspend 후 재개**
+- [ ] **코드블록은 skip + auto-scroll 에서도 건너뜀**
+- [ ] 페이지 나갈 때 음성 자동 종료 (`cancel()`) + `tts-active-block` class 정리
+- [ ] 인터넷 끊긴 상태에서도 재생 가능 (offline voice 사용)
+
+### 5.2 UX
+
+- [ ] "Listen" 버튼이 PostHero 하단에 명확히 보임 (모바일 375px, 데스크톱 1920px 모두)
+- [ ] 버튼 클릭 후 1초 이내 첫 utterance 시작
+- [ ] player UI가 기존 Tailwind 토큰 (`bg-surface`, `text-accent`, `border-border`) 일관 사용
+- [ ] 버튼의 accessible label (`aria-label="Listen to article"`) 부여
+
+### 5.3 Non-functional
+
+- [ ] 번들 크기 추가 < 5 KB gzipped (client component만 client 번들로 split)
+- [ ] 첫 `speak()` 호출 전까지 `speechSynthesis` 초기화 없음 (lazy)
+- [ ] TypeScript 컴파일 에러 0
+- [ ] Next.js build 성공 (기존 SSG 페이지 영향 없음)
+- [ ] Console errors 0
+
+## 6. 타임라인
+
+| 단계 | 예상 | 산출물 |
+|---|:--:|---|
+| Plan (본 문서) | 30m | `docs/01-plan/blog-tts.plan.md` |
+| Design | 45m | `docs/02-design/features/blog-tts.design.md` — 컴포넌트 API + 상태 머신 + 엣지 케이스 |
+| Do | 2-3h | `src/components/blog/tts-*.tsx` 2-3 파일, `post-hero.tsx` + `track.ts` 수정 |
+| QA | 1h | Chrome MCP 자동 재생 + 수동 실측 (여러 브라우저) |
+| Report | 30m | `docs/03-report/blog-tts-YYYY-MM-DD.md` |
+| Commit + PR | 15m | PR → staging |
+| **Total** | **~5-6h** | |
+
+## 7. 리스크 & 완화
+
+| 리스크 | 확률 | 영향 | 완화 |
+|---|:-:|:-:|------|
+| Chrome 15초 버그로 중간 끊김 | 중 | 고 | 160자 chunk + onend 큐 (ttsreader 패턴) |
+| iOS Safari 첫 `speak()` 차단 | 중 | 고 | user-gesture handler 내부에서 동기 호출. 제스처 끊김 피하도록 async/await 사용 X |
+| `getVoices()` 빈 배열 반환 (Chrome 초기) | 높 | 중 | `onvoiceschanged` 리스너 + useEffect 재시도 |
+| 긴 글 (2,500단어) 재생 시 배터리 소모 | 낮 | 저 | 경고 표시 불필요 (사용자가 능동 재생) |
+| `boundary` 이벤트 Firefox에서 미발사 | 높 | 저 | MVP는 단어 하이라이트 안 하므로 무관 |
+| MDX 이미지 alt text가 읽힘 | 낮 | 저 | `textContent` 추출은 alt text 포함 안 함 (표준 DOM 동작) |
+| 독자가 끄는 걸 잊고 다음 글로 이동 → 두 음성 겹침 | 낮 | 중 | Next.js route change listener + `cancel()` |
+| CSP 위반 | 낮 | 중 | Web Speech API는 외부 요청 없음. CSP 무관. `next.config.ts` 검증 완료 (code analysis §G) |
+
+## 8. 배포 플로우
+
+```
+feature/blog-tts  (staging 기준)
+    ├─ commit 1: analytics EventMap 확장
+    ├─ commit 2: TTSPlayer 컴포넌트 + TTSButton 컴포넌트
+    ├─ commit 3: PostHero 통합 + build verify
+    └─ PR → staging → CI → merge
+         ↓
+      main PR 은 사용자 검토 후 직접
+```
+
+## 9. Check phase (QA) 계획 미리보기
+
+Design 완료 후 상세화 예정. 핵심 항목:
+
+### 9.1 Chrome MCP 자동 검증
+
+- /blog/{slug} navigate → "Listen" 버튼 렌더 확인
+- 버튼 클릭 → `speechSynthesis.speaking` true 확인
+- Pause 클릭 → `paused` true 확인
+- 다른 글로 이동 → 이전 글 음성 cancel 확인
+
+### 9.2 수동 cross-browser
+
+- macOS Safari 17+
+- macOS Chrome (Apple Silicon)
+- macOS Firefox
+- iOS Safari (실기기 권장)
+
+각 브라우저에서:
+- 첫 30초 재생 OK
+- Chunk 경계에서 끊김 없음
+- Speed slider 실시간 반영
+
+### 9.3 Layout regression
+
+- Chrome MCP `blog-content.md §7.1` 계약 유지 — hero max-w-3xl, articleWidth 720, gridCols "720px 220px"
+- 모바일 375px 가로 스크롤 0
+- Listen 버튼이 네 카테고리 글 모두에서 동일 위치
+
+## 10. 의존성 / 선행 조건
+
+- **선행**: 없음 (blog-categories, release-pipeline-resilience 모두 staging에 머지 완료, main 기다림)
+- **병행 가능**: homebrew 재활성 결정 — 별개 이슈
+- **후속**:
+  - Phase B — 단어/문장 하이라이트 + 재생 위치 저장 (MVP 사용 데이터 보고 결정)
+  - Phase C — 한국어 글 추가 시 다국어 voice auto-detect
+  - Phase D — 모바일 floating mini-player (사용자 요청 들어오면)
+
+## 11. Out-of-scope 명시
+
+이 PDCA 에서 다루지 않는 것:
+
+- 오디오 파일 다운로드 기능 (MP3 export)
+- 재생 속도 외 pitch/volume 조정
+- 재생 중 광고 삽입 / 후원 음성
+- 소셜 공유용 오디오 snippet 생성
+- Podcast RSS feed (팟캐스트 앱 구독 대응)
+
+필요해지면 각각 별도 plan 문서로.
+
+## 12. 참조 (리서치 원본)
+
+- ttsreader hosted: https://ttsreader.com/
+- ttsreader 웹사이트 repo (Hugo): https://github.com/ttsreader/ttsreader-web
+- ttsreader 엔진 repo (RonenR, vanilla JS): https://github.com/RonenR/ttsreader
+- Chromium 15초 버그: #679437, #335907
+- 3rd-party 폴리필 레퍼런스: https://github.com/leaonline/easy-speech
+- Web Speech API 스펙 draft: https://webaudio.github.io/web-speech-api/
+- tene 기존 PostHero: `apps/web/src/components/blog/post-hero.tsx`
+- tene 기존 page: `apps/web/src/app/blog/[slug]/page.tsx:129` (article container)
+- tene track EventMap: `apps/web/src/lib/track.ts:6-55`
+- tene next.config CSP: `apps/web/next.config.ts:9-16` — Web Speech 무관, 변경 불필요
+- tene tsconfig: dom/dom.iterable 포함 — `speechSynthesis` 타입 자동 resolve
+
+---
+
+**작성**: 2026-04-24 (Claude main + /pdca team 병렬 리서치 2건)
+**승인 대기**: 사용자 확인 후 Design 단계 진입

--- a/docs/01-plan/release-pipeline-resilience.plan.md
+++ b/docs/01-plan/release-pipeline-resilience.plan.md
@@ -1,0 +1,162 @@
+# Release Pipeline Resilience — Plan
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `release-pipeline-resilience` |
+| 기반 컨텍스트 | v1.0.5, v1.0.6, v1.0.7 세 번 연속 동일 실패 |
+| 브랜치 | `fix/release-pipeline-resilience` (origin/staging 베이스) |
+| 관련 이전 시도 | PR #66 (비슷한 fix 제안, 사용자가 close/revert함) |
+| 총 공수 | ~2-3 인시간 |
+
+---
+
+## 1. 문제 요약 (Why now)
+
+지난 3번의 안정 릴리스(v1.0.5, v1.0.6, v1.0.7) 모두 **동일한 증상**으로 실패 처리됨:
+
+1. GoReleaser가 바이너리 빌드 + S3 업로드 + Docker GHCR publish + GitHub Release 모두 **성공**
+2. 마지막 `homebrew formula` 단계에서 `tomo-kay/homebrew-tene` 리포(존재하지 않음) 401
+3. goreleaser 전체 exit 1
+4. 다음 스텝 `Update LATEST_VERSION (stable only)`가 **GitHub Actions 기본 동작(이전 스텝 실패 시 skip)** 으로 스킵됨
+5. 결과: `install.sh`가 참조하는 S3 `LATEST_VERSION` 파일이 **2번 연속 수동 핫픽스** 필요했음 (4/23, 4/24)
+
+### 1.1 실측 증거
+
+```bash
+# main v1.0.7 Auto Tag & Release (2026-04-24 12:27) 로그 마지막:
+• release published url=https://github.com/tomo-kay/tene/releases/tag/v1.0.7
+• homebrew formula
+• error checking for default branch projectID=tomo-kay/homebrew-tene statusCode=401
+⨯ release failed after 1m47s
+error=homebrew formula: could not get default branch: 401 Bad credentials
+
+# S3 LATEST_VERSION 당시 상태:
+curl https://tene-releases.s3.ap-northeast-2.amazonaws.com/LATEST_VERSION
+# → 1.0.5  (수동 hotfix 그대로, 1.0.6 / 1.0.7 배포됐음에도)
+```
+
+## 2. 사용자 확정 방향
+
+사용자 의도 (2026-04-24 세션):
+
+1. **"LATEST_VERSION 업데이트를 CICD에 항상 포함해야겠어"** — 어떤 스텝 실패에도 install.sh 포인터는 갱신되어야
+2. **"homebrew는 아직 대응안할거야"** — 당분간 비활성화. 나중에 `tomo-kay/homebrew-tene` 저장소 + PAT 준비 시 재활성화
+3. 두 조치 모두 CICD 코드 변경 필요
+
+## 3. 스코프
+
+### 3.1 변경 대상 2개 파일
+
+| 파일 | 변경 이유 | 변경 요약 |
+|------|----------|----------|
+| `.github/workflows/auto-tag.yml` | LATEST_VERSION 항상 실행 | `if: always()` 가드 + S3 tarball 존재 검증 |
+| `.goreleaser.yml` | Homebrew publish 비활성 | `brews:` 섹션 주석 처리 + 복원 가이드 |
+
+### 3.2 변경 비대상 (의도적 제외)
+
+- `install.sh` — 변경 없음 (S3 `LATEST_VERSION` 파일 갱신만 신경 쓰면 됨)
+- `dockers:` 섹션 — 정상 작동 중, 변경 없음
+- `blobs:` 섹션 — 정상 작동 중, 변경 없음
+- `tomo-kay/homebrew-tene` 리포 — 생성 보류 (사용자 결정)
+- `HOMEBREW_TAP_GITHUB_TOKEN` secret — 설정 보류
+
+### 3.3 문서 업데이트
+
+- `docs/01-plan/release-pipeline-resilience.plan.md` (이 문서)
+- `docs/02-design/features/release-pipeline-resilience.design.md` (설계 상세)
+- `CHANGELOG.md` — Unreleased 섹션의 Fixed 엔트리
+- `docs/03-report/release-pipeline-resilience-YYYY-MM-DD.md` (완료 후)
+
+## 4. 의사결정 요약
+
+### 4.1 LATEST_VERSION 갱신 보장 방식 (4가지 검토 → 1 택)
+
+| 옵션 | 내용 | 평가 |
+|------|-----|------|
+| A. `if: always()` + tarball 존재 가드 | goreleaser가 어느 단계에서 실패하든 LATEST_VERSION 시도. 단, 실제 바이너리가 S3에 없으면 update 거부. | ✅ **선택** — 기회적으로 항상 시도하되 잘못된 포인터 방지 |
+| B. goreleaser job 성공/실패와 무관하게 별도 job으로 분리 | 전체 release job 완료 후 `needs:` + `if:` 로 분기 | 과한 구조 변경 |
+| C. post-install 체크 스크립트 | install.sh가 이상 감지 시 GitHub API fallback | install.sh 변경 필요 + 사용자 환경에 curl 의존 |
+| D. Cron job으로 매시간 sync | GitHub latest release ↔ S3 LATEST_VERSION 동기화 | 새 cron workflow 추가 + 지연 시간 발생 |
+
+### 4.2 Homebrew 비활성 방식 (3가지 검토 → 1 택)
+
+| 옵션 | 내용 | 평가 |
+|------|-----|------|
+| A. `brews:` 섹션 전체 주석 처리 | goreleaser 실행 시 brews 단계 자체가 없음 | ✅ **선택** — 실수 여지 최소, 복원 시 주석 제거 1줄 |
+| B. `skip_upload: true` | Formula 파일 로컬 생성하되 push 안 함 | 실험 결과 `check default branch` API 호출은 skip_upload 전에 발생 → 여전히 401 |
+| C. `brews:` 블록 삭제 | 히스토리 상실, git log에서 복원 의도 추적 어려움 | 비대체 권장 |
+
+## 5. 검증 계획 (QA Phase)
+
+실제 v1.0.8 태그를 잘라보는 건 너무 파괴적. 대신 **정적 분석 + 과거 실패 시나리오 재현**:
+
+### 5.1 YAML 문법 검증
+```bash
+yq '.' .github/workflows/auto-tag.yml > /dev/null  # 구문 에러 없음
+```
+
+### 5.2 의존성 그래프 분석
+- `Update LATEST_VERSION` step의 `if:` 조건이 모든 주요 시나리오에서 올바르게 평가되는지 매트릭스 검증
+
+| 시나리오 | goreleaser 결과 | auto-tag.outputs.version | if 평가 | 기대 동작 |
+|---------|----------|--------|--------|----------|
+| main stable, 바이너리 S3 업로드 성공 후 homebrew 실패 | failure | `v1.0.8` | `always() && !contains(v1.0.8, '-rc')` = true | 실행 → S3 ls 통과 → LATEST_VERSION=1.0.8 |
+| main stable, 바이너리 업로드 전 실패 | failure | `v1.0.8` | true | 실행 → S3 ls 실패 → exit 1 (포인터 보호) |
+| staging rc tag | any | `v1.0.8-rc1` | false | skip |
+| 전부 성공 (가상 시나리오) | success | `v1.0.8` | true | 실행 → LATEST_VERSION 갱신 |
+
+### 5.3 goreleaser dry-run
+```bash
+# goreleaser check로 config 유효성 확인
+cd tene && goreleaser check  # brews 주석 처리 후에도 config 유효
+```
+
+### 5.4 실제 운영 검증 (릴리스 후)
+
+현재 PDCA 사이클에서 실행 가능한 건 3번째까지. 실제 동작은 **다음 stable 릴리스(v1.0.8 또는 v1.0.6 재배포)** 시점까지 확인 보류.
+
+## 6. 타임라인
+
+| 단계 | 예상 소요 | 산출물 |
+|------|:--:|------|
+| Plan (본 문서) | 30m | `docs/01-plan/release-pipeline-resilience.plan.md` |
+| Design | 30m | `docs/02-design/features/release-pipeline-resilience.design.md` |
+| Do | 20m | 2개 파일 수정 + CHANGELOG + commit |
+| QA | 30m | YAML 검증 + 시나리오 매트릭스 |
+| Report | 20m | `docs/03-report/release-pipeline-resilience-2026-04-24.md` |
+| PR + merge (staging → main) | 20m | 브랜치 push + PR #XX |
+| **Total** | **~2.5h** | |
+
+## 7. 리스크 & 완화
+
+| 리스크 | 확률 | 영향 | 완화 |
+|---|:-:|:-:|------|
+| `if: always()` 추가로 인해 goreleaser 실패해도 LATEST_VERSION이 갱신되어 깨진 버전 공개 | 낮 | 고 | S3 tarball 존재 검증 가드로 차단 |
+| brews: 주석 처리 후 다른 섹션(dockers/blobs) 영향 | 낮 | 저 | goreleaser config는 독립 블록. QA에서 goreleaser check로 검증 |
+| 다음 릴리스에서 또 다른 예외 케이스 노출 | 중 | 중 | Report에 모니터링 지점 명시. 재발 시 재플랜 |
+| 사용자가 언젠가 homebrew 켤 때 복원 과정에서 혼란 | 낮 | 저 | `.goreleaser.yml` 주석 블록에 복원 가이드 명시 |
+
+## 8. 성공 기준
+
+- 다음 stable 릴리스 1회 경과 후:
+  - goreleaser exit 0 (brews 단계 없어짐)
+  - Auto Tag & Release workflow 상태 = success
+  - S3 `LATEST_VERSION` 파일 자동 갱신됨 (수동 hotfix 불필요)
+  - `install.sh`로 설치 시 최신 버전 도달
+- Homebrew publish는 여전히 안 됨 (의도적)
+
+---
+
+## 9. 참조
+
+- 과거 실패 로그: GitHub Actions run 24826937468 (v1.0.5), 24888395413 (v1.0.6), 24889443661 (v1.0.7)
+- 수동 hotfix 이력:
+  - 2026-04-23 11:06:48 UTC — S3 LATEST_VERSION 1.0.4 → 1.0.5
+  - 2026-04-24 12:50:03 UTC — S3 LATEST_VERSION 1.0.5 → 1.0.7
+- 이전 PR #66 (close됨) — 유사 제안 포함했으나 homebrew-tene 생성 경로와 함께 묶어서 제시하여 사용자가 거부
+- 관련 파일: `.github/workflows/auto-tag.yml:150-158`, `.goreleaser.yml:91-120`, `apps/web/public/install.sh:39-47`
+
+---
+
+**작성**: 2026-04-24 (Claude main, 사용자 요청)
+**승인 대기**: 사용자 확인 후 Design → Do 진입

--- a/docs/02-design/features/blog-tts.design.md
+++ b/docs/02-design/features/blog-tts.design.md
@@ -1,0 +1,777 @@
+# Blog TTS — Design
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `blog-tts` |
+| Plan | `docs/01-plan/blog-tts.plan.md` |
+| 브랜치 | `feature/blog-tts` |
+| 리서치 기반 | /pdca team 2 agents (2026-04-24): scroll sync tech + tene 코드베이스 |
+
+---
+
+## 1. 아키텍처 오버뷰
+
+```
+apps/web/src/
+├── components/blog/
+│   ├── post-hero.tsx            [수정] — server component. <TTSButton> import + 렌더
+│   ├── tts-button.tsx           [신규] — client. 글 하단 "Listen" 트리거. 처음 누르면 <TTSPlayer> mount
+│   ├── tts-player.tsx           [신규] — client. 실제 재생 로직, UI, 상태 관리
+│   └── tts-controls.tsx         [신규] — client. play/pause/stop/speed/voice UI (presentational)
+├── lib/
+│   ├── tts/
+│   │   ├── chunks.ts            [신규] — extractChunks + chunkText 순수 함수
+│   │   ├── prefs.ts             [신규] — localStorage load/save (namespaced tene:blog-tts)
+│   │   └── voices.ts            [신규] — getVoices 구독 hook + en-* 필터
+│   └── track.ts                 [수정] — EventMap에 TTS 이벤트 6종 추가
+├── hooks/
+│   ├── use-tts.ts               [신규] — speech synthesis 생명주기 훅
+│   └── use-scroll-sync.ts       [신규] — 문단 scrollIntoView + user-scroll 감지
+└── app/
+    ├── blog/[slug]/page.tsx     [영향 없음] — 기존 PostHero 호출 유지
+    └── globals.css              [수정] — .tts-active-block 클래스 + scroll-margin 추가
+```
+
+**요약**: 컴포넌트 3개 + 훅 2개 + 유틸 3개 + 전역 CSS 1블록 + track.ts 확장 + post-hero.tsx 1줄 추가.
+
+예상 client 번들 증가: **~4 KB gzipped** (Plan 목표 < 5 KB 충족).
+
+---
+
+## 2. 컴포넌트 설계
+
+### 2.1 `<TTSButton>` — 진입점
+
+**파일**: `src/components/blog/tts-button.tsx`
+**타입**: Client component
+**Props**:
+```ts
+type TTSButtonProps = {
+  slug: string;          // analytics용
+  readingMinutes: number; // analytics payload
+};
+```
+
+**동작**:
+- 렌더 초기: `<button>Listen</button>` 하나만
+- 클릭 시: `<TTSPlayer>` 를 lazy mount + 자동 play 시작
+- 이유: unmount 상태에서는 speechSynthesis API에 닿지 않음 → 번들/성능 비용 거의 0
+
+**UI (Tailwind)**:
+```tsx
+<button
+  aria-label="Listen to article"
+  className="inline-flex items-center gap-2 rounded-md border border-border bg-surface/60 px-3 py-1.5 text-sm text-muted backdrop-blur-sm transition-colors hover:border-accent/40 hover:text-foreground"
+>
+  <PlayIcon className="h-4 w-4" />
+  Listen
+</button>
+```
+
+아이콘: 인라인 SVG (lucide-react 같은 런타임 의존성 추가 없음 — 기존 코드베이스 convention).
+
+### 2.2 `<TTSPlayer>` — 재생 오케스트레이터
+
+**파일**: `src/components/blog/tts-player.tsx`
+**타입**: Client component
+**Props**:
+```ts
+type TTSPlayerProps = {
+  slug: string;
+  readingMinutes: number;
+  onClose?: () => void;  // 명시적 중단 시 부모에게 unmount 신호
+};
+```
+
+**책임**:
+1. `useTTS()` 훅으로 재생 라이프사이클 관리
+2. `useScrollSync()` 훅으로 문단 자동 추적
+3. `<TTSControls>` 에 상태 + 콜백 전달
+4. 페이지 언마운트 시 cleanup
+
+**상태 (하위 훅이 소유, Player는 orchestrator)**:
+- `chunks: TTSChunk[]` — `useRef` (재렌더 트리거 안 함)
+- `currentChunkIndex: number` — `useState`
+- `playbackState: 'idle' | 'playing' | 'paused'`
+- `voices: SpeechSynthesisVoice[]`
+- `selectedVoiceURI: string | null`
+- `rate: number`
+
+**Chunk 추출 타이밍**:
+- Player mount 직후 `useLayoutEffect` 에서 `extractChunks(articleEl)` 1회 실행
+- 결과를 `chunksRef.current` 에 저장
+- `articleEl = document.querySelector('article.min-w-0')` — `page.tsx:129` 에 이미 안정적 셀렉터 존재
+
+### 2.3 `<TTSControls>` — 프리젠테이셔널 UI
+
+**파일**: `src/components/blog/tts-controls.tsx`
+**타입**: Client component (순수 UI, 로직 없음)
+**Props**:
+```ts
+type TTSControlsProps = {
+  state: 'idle' | 'playing' | 'paused';
+  progress: { current: number; total: number };
+  rate: number;
+  voices: SpeechSynthesisVoice[];
+  selectedVoiceURI: string | null;
+  onPlay: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  onRateChange: (rate: number) => void;
+  onVoiceChange: (voiceURI: string) => void;
+};
+```
+
+**UI 레이아웃** (PostHero 내부, description 아래 inline card):
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ▶ Play    0:00 / 11:32       [●────────○]  Chunk 12/87    │
+│                                                             │
+│  Speed  [1x ▼]   Voice  [Samantha (en-US) ▼]   ✕ Close     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- 상단: Play/Pause 토글 + 시간 표시 (예상; `currentChunk * avgSec`) + progress bar + chunk counter
+- 하단: Speed select (0.5 / 0.75 / 1 / 1.25 / 1.5 / 2) + Voice dropdown + Close 버튼
+
+**토큰**: 기존 tene 스타일과 동일 (`bg-surface/60`, `border-border`, `text-accent`).
+
+---
+
+## 3. 훅 설계
+
+### 3.1 `useTTS()` — speech synthesis 생명주기
+
+**파일**: `src/hooks/use-tts.ts`
+
+**Signature**:
+```ts
+interface UseTTSOptions {
+  chunks: React.RefObject<TTSChunk[]>;
+  voice: SpeechSynthesisVoice | null;
+  rate: number;
+  onChunkChange?: (index: number) => void;
+  onComplete?: () => void;
+  onError?: (err: SpeechSynthesisErrorEvent) => void;
+}
+
+interface UseTTSReturn {
+  state: 'idle' | 'playing' | 'paused';
+  currentChunkIndex: number;
+  play: () => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+}
+
+function useTTS(options: UseTTSOptions): UseTTSReturn;
+```
+
+**내부 동작**:
+
+```ts
+// 1. 첫 play 클릭 시 동기 호출 (iOS gesture 유지)
+const play = useCallback(() => {
+  if (!chunks.current?.length) return;
+  speechSynthesis.cancel();  // 이전 잔여 utterance 제거
+  indexRef.current = 0;
+  setState('playing');
+  speakNext();  // sync call, no await
+}, []);
+
+// 2. chunk 큐 순차 처리
+const speakNext = () => {
+  const idx = indexRef.current;
+  const chunk = chunks.current?.[idx];
+  if (!chunk) {
+    setState('idle');
+    onComplete?.();
+    return;
+  }
+  const u = new SpeechSynthesisUtterance(chunk.text);
+  u.voice = voice;
+  u.lang = voice?.lang ?? 'en-US';
+  u.rate = Math.min(Math.max(rate, 0.5), 2);
+  u.onstart = () => {
+    setCurrentChunkIndex(idx);
+    onChunkChange?.(idx);
+  };
+  u.onend = () => {
+    indexRef.current++;
+    speakNext();
+  };
+  u.onerror = (e) => {
+    // Chrome emits 'interrupted' on cancel — not a real error
+    if (e.error !== 'interrupted' && e.error !== 'canceled') {
+      onError?.(e);
+    }
+  };
+  speechSynthesis.speak(u);
+};
+
+// 3. pause/resume — 원자성 보장
+const pause = () => {
+  speechSynthesis.pause();
+  setState('paused');
+};
+const resume = () => {
+  speechSynthesis.resume();
+  setState('playing');
+};
+
+// 4. stop — queue 플러시
+const stop = () => {
+  speechSynthesis.cancel();
+  indexRef.current = 0;
+  setCurrentChunkIndex(0);
+  setState('idle');
+};
+
+// 5. unmount cleanup
+useEffect(() => {
+  return () => speechSynthesis.cancel();
+}, []);
+```
+
+**엣지 케이스**:
+- **rate 변경 중 재생**: 현재 재생 중 utterance는 기존 rate 유지. 다음 chunk부터 새 rate 적용. 즉시 반영 원하면: `cancel()` + 현재 `indexRef` 유지 + `speakNext()` 재호출.
+- **voice 변경 중 재생**: 동일. 단, 다음 chunk 시점에서 중단감 느껴질 수 있음 → UI에 "Voice will apply from next paragraph" hint.
+- **탭 backgrounding**: Chrome은 백그라운드 탭에서 `speechSynthesis` 일시정지함. `visibilitychange` listener 로 UI 상태 sync.
+
+### 3.2 `useScrollSync()` — 문단 추적 + user-scroll 존중
+
+**파일**: `src/hooks/use-scroll-sync.ts`
+
+```ts
+interface UseScrollSyncOptions {
+  chunks: React.RefObject<TTSChunk[]>;
+  currentChunkIndex: number;
+  enabled: boolean;  // false면 hook 아무 것도 안 함
+}
+
+function useScrollSync(options: UseScrollSyncOptions): void;
+```
+
+**구현** (리서치 Agent A 제시 패턴 채택):
+
+```ts
+const prevBlockIdxRef = useRef<number | null>(null);
+const prevElRef = useRef<HTMLElement | null>(null);
+const programmaticRef = useRef(false);
+const userScrolledAtRef = useRef(0);
+const SUSPEND_MS = 2500;
+
+// User scroll 감지
+useEffect(() => {
+  const onScroll = () => {
+    if (programmaticRef.current) return;
+    userScrolledAtRef.current = Date.now();
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
+  return () => window.removeEventListener('scroll', onScroll);
+}, []);
+
+// Chunk 변경에 반응
+useEffect(() => {
+  if (!enabled) return;
+  const chunk = chunks.current?.[currentChunkIndex];
+  if (!chunk) return;
+
+  // Highlight 항상 swap
+  if (prevElRef.current && prevElRef.current !== chunk.blockEl) {
+    prevElRef.current.removeAttribute('data-tts-active');
+  }
+  chunk.blockEl.setAttribute('data-tts-active', 'true');
+  prevElRef.current = chunk.blockEl;
+
+  // 같은 문단 내 chunk 이동이면 scroll skip
+  if (prevBlockIdxRef.current === chunk.blockIndex) return;
+  prevBlockIdxRef.current = chunk.blockIndex;
+
+  // User scroll 쿨다운
+  if (Date.now() - userScrolledAtRef.current < SUSPEND_MS) return;
+
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  programmaticRef.current = true;
+  chunk.blockEl.scrollIntoView({
+    behavior: reduced ? 'auto' : 'smooth',
+    block: 'center',
+  });
+  const t = setTimeout(() => {
+    programmaticRef.current = false;
+  }, 800);
+  return () => clearTimeout(t);
+}, [chunks, currentChunkIndex, enabled]);
+
+// Disabled / unmount cleanup
+useEffect(() => {
+  if (!enabled && prevElRef.current) {
+    prevElRef.current.removeAttribute('data-tts-active');
+    prevElRef.current = null;
+    prevBlockIdxRef.current = null;
+  }
+}, [enabled]);
+```
+
+---
+
+## 4. 순수 유틸
+
+### 4.1 `src/lib/tts/chunks.ts`
+
+```ts
+export interface TTSChunk {
+  text: string;
+  blockIndex: number;
+  blockEl: HTMLElement;
+}
+
+/**
+ * Split long text into sentence-aligned chunks ≤ maxLen chars.
+ * Works around the Chrome 15-second utterance cutoff by ensuring
+ * no single utterance exceeds the chunk length.
+ */
+export function chunkText(text: string, maxLen = 160): string[] {
+  const re = new RegExp(
+    `[\\s\\S]{1,${maxLen}}[.!?,](?=\\s|$)|[\\s\\S]{1,${maxLen}}`,
+    'g',
+  );
+  return text.match(re) ?? [text];
+}
+
+const BLOCK_SELECTOR = 'p, h2, h3, h4, h5, li, blockquote';
+
+/**
+ * Extract speakable chunks from the rendered article DOM.
+ * Skips code blocks (descendants of <pre>), autolink anchor text
+ * (rehypeAutolinkHeadings adds `.heading-anchor`), and empty blocks.
+ */
+export function extractChunks(articleEl: HTMLElement): TTSChunk[] {
+  const blocks = Array.from(articleEl.querySelectorAll<HTMLElement>(BLOCK_SELECTOR))
+    .filter((el) => !el.closest('pre'))       // skip inside block code
+    .filter((el) => !isEmpty(el));
+
+  const chunks: TTSChunk[] = [];
+  blocks.forEach((el, blockIndex) => {
+    const text = readableText(el);
+    if (!text) return;
+    chunkText(text, 160).forEach((t) => {
+      chunks.push({ text: t, blockIndex, blockEl: el });
+    });
+  });
+  return chunks;
+}
+
+/** Strip autolink anchor "#" text and normalize whitespace. */
+function readableText(el: HTMLElement): string {
+  const clone = el.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll('.heading-anchor, [aria-hidden="true"]').forEach((n) => n.remove());
+  return (clone.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function isEmpty(el: HTMLElement): boolean {
+  return !(el.textContent ?? '').trim();
+}
+```
+
+**커버리지 검증** (코드베이스 Agent B 결과 기반):
+- ✅ `<p>` (mdx-components.tsx:49)
+- ✅ `<h2>`, `<h3>`, `<h4>` (mdx-components.tsx:28-47)
+- ✅ `<li>` (mdx-components.tsx:85-88)
+- ✅ `<blockquote>` (mdx-components.tsx:90-96)
+- ⚠️ `<Callout>` 내부 텍스트: 렌더되면 `<aside>` 블록. 현재 selector에 없음. **후속 결정**: MVP는 Callout 무시, 필요시 Phase B에서 추가.
+- ⚠️ `<td>` (테이블 셀): 같은 이유로 MVP 제외.
+- ⚠️ `<GifEmbed>` 의 `<figcaption>`: 마찬가지로 MVP 제외.
+
+이 결정은 "핵심 본문 prose는 읽되, 보조 UI 요소는 스킵" 원칙과 일치.
+
+### 4.2 `src/lib/tts/prefs.ts`
+
+단일 JSON object 방식 (리서치 Agent A 권장):
+
+```ts
+const STORAGE_KEY = 'tene:blog-tts';
+const VERSION = 1;
+
+export interface TTSPrefs {
+  v: number;            // schema version
+  voiceURI: string | null;
+  rate: number;         // clamped [0.5, 2]
+}
+
+const DEFAULTS: TTSPrefs = { v: VERSION, voiceURI: null, rate: 1 };
+
+export function loadPrefs(): TTSPrefs {
+  if (typeof window === 'undefined') return DEFAULTS;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    const parsed = JSON.parse(raw);
+    if (parsed?.v !== VERSION) return DEFAULTS; // future-proof schema migration
+    return {
+      v: VERSION,
+      voiceURI: typeof parsed.voiceURI === 'string' ? parsed.voiceURI : null,
+      rate: clampRate(parsed.rate),
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+let memoryFallback: TTSPrefs | null = null;
+
+export function savePrefs(patch: Partial<Omit<TTSPrefs, 'v'>>): void {
+  if (typeof window === 'undefined') return;
+  const current = memoryFallback ?? loadPrefs();
+  const next: TTSPrefs = {
+    ...current,
+    ...patch,
+    v: VERSION,
+    rate: patch.rate != null ? clampRate(patch.rate) : current.rate,
+  };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    memoryFallback = null;
+  } catch {
+    // iOS Safari private mode → in-memory fallback
+    memoryFallback = next;
+  }
+}
+
+function clampRate(r: unknown): number {
+  const n = typeof r === 'number' ? r : parseFloat(String(r));
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(Math.max(n, 0.5), 2);
+}
+```
+
+**선택 근거**:
+- 원자성 (단일 `setItem` 호출)
+- 버전 필드로 후속 schema 변경 안전
+- Private mode fallback 명시
+- SSR safe
+
+### 4.3 `src/lib/tts/voices.ts`
+
+```ts
+import { useEffect, useState } from 'react';
+
+/**
+ * Chrome returns [] on first getVoices() call; voices populate
+ * asynchronously and fire 'voiceschanged'. Safari returns them
+ * synchronously with no event. This hook handles both.
+ */
+export function useVoices(): SpeechSynthesisVoice[] {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('speechSynthesis' in window)) return;
+    const update = () => setVoices(window.speechSynthesis.getVoices());
+    update();
+    window.speechSynthesis.addEventListener('voiceschanged', update);
+    return () => window.speechSynthesis.removeEventListener('voiceschanged', update);
+  }, []);
+
+  return voices;
+}
+
+/**
+ * Voices filtered to the given language prefix (e.g. 'en' matches en-US, en-GB, ...).
+ */
+export function filterByLangPrefix(
+  voices: SpeechSynthesisVoice[],
+  prefix: string,
+): SpeechSynthesisVoice[] {
+  return voices.filter((v) => v.lang.toLowerCase().startsWith(prefix.toLowerCase()));
+}
+
+/**
+ * Select the best voice given saved URI + available list.
+ * Fallback order: saved URI → default en-* voice → first en-* → first voice → null.
+ */
+export function pickBestVoice(
+  all: SpeechSynthesisVoice[],
+  savedURI: string | null,
+  langPrefix = 'en',
+): SpeechSynthesisVoice | null {
+  if (!all.length) return null;
+  const matches = filterByLangPrefix(all, langPrefix);
+  return (
+    matches.find((v) => v.voiceURI === savedURI) ??
+    matches.find((v) => v.default) ??
+    matches[0] ??
+    all[0] ??
+    null
+  );
+}
+```
+
+---
+
+## 5. 상태 머신
+
+```
+        ┌───────┐
+        │ idle  │◀─────────────┐
+        └───┬───┘              │
+            │ play()           │ stop() or complete
+            ▼                  │
+        ┌───────┐              │
+        │playing│──────────────┤
+        └──┬─▲──┘              │
+           │ │                 │
+    pause()│ │resume()         │
+           ▼ │                 │
+        ┌───────┐              │
+        │paused │──────────────┘
+        └───────┘
+```
+
+**트랜지션 & 부작용 매트릭스**:
+
+| 트리거 | from | to | 부작용 |
+|---|---|---|---|
+| play() | idle | playing | cancel() → indexRef=0 → speakNext() |
+| pause() | playing | paused | speechSynthesis.pause() |
+| resume() | paused | playing | speechSynthesis.resume() |
+| stop() | any | idle | cancel() → highlight 해제 → currentChunkIndex=0 |
+| complete (last chunk onend) | playing | idle | onComplete callback → 이벤트 발사 → highlight 해제 |
+| rate change | playing | playing | (next chunk 부터 반영) |
+| voice change | playing | playing | (next chunk 부터 반영) |
+| unmount | any | N/A | cancel() + highlight 해제 |
+| visibilitychange hidden | playing | paused | speechSynthesis.pause() |
+| visibilitychange visible | paused(by hidden) | playing | speechSynthesis.resume() |
+
+---
+
+## 6. CSS 변경 (globals.css)
+
+```css
+/* ─────────────────────────────────────────────
+   TTS — paragraph auto-scroll + active highlight
+   ───────────────────────────────────────────── */
+
+/* scroll-margin for scrollIntoView({block:'start'}) fallback.
+   Not needed for block:'center' but cheap defense. */
+article p,
+article h2,
+article h3,
+article h4,
+article h5,
+article li,
+article blockquote {
+  scroll-margin-top: 80px;
+}
+
+/* Active paragraph highlight — specificity (0,1,1) */
+article [data-tts-active="true"] {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-left: 2px solid var(--accent);
+  padding-left: 0.75rem;
+  margin-left: -0.875rem;  /* 0.75rem padding + 2px border offset */
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    padding-left 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  article [data-tts-active="true"] {
+    transition: none;
+  }
+}
+```
+
+**배치**: `globals.css` 파일 끝에 `/* TTS block */` 섹션 추가.
+
+---
+
+## 7. Analytics events 설계
+
+`src/lib/track.ts` `EventMap` 에 추가:
+
+```ts
+blog_tts_play: {
+  slug: string;
+  readingMinutes: number;
+  voice?: string;          // voiceURI
+  rate?: number;
+};
+blog_tts_pause: {
+  slug: string;
+  percentRead: number;     // Math.round(currentChunkIndex / total * 100)
+};
+blog_tts_resume: {
+  slug: string;
+  percentRead: number;
+};
+blog_tts_stop: {
+  slug: string;
+  percentRead: number;
+};
+blog_tts_complete: {
+  slug: string;
+  readingMinutes: number;
+};
+blog_tts_rate_change: {
+  slug: string;
+  rate: number;
+};
+blog_tts_voice_change: {
+  slug: string;
+  voiceName: string;
+};
+```
+
+**발사 지점**:
+- `play()` → `blog_tts_play` (prefs + readingMinutes 함께)
+- `pause()` → `blog_tts_pause`
+- `resume()` → `blog_tts_resume`
+- `stop()` → `blog_tts_stop`
+- `onComplete` → `blog_tts_complete`
+- Speed select `onChange` → `blog_tts_rate_change`
+- Voice select `onChange` → `blog_tts_voice_change`
+
+---
+
+## 8. 엣지 케이스 & 대응
+
+| # | 케이스 | 대응 |
+|:-:|---|---|
+| E1 | Chrome 첫 `getVoices()` 가 빈 배열 반환 | `useVoices()` hook 이 `voiceschanged` 이벤트 구독. 초기 빈 상태에서도 Play 버튼은 활성 — voice=null이면 browser default 사용 |
+| E2 | iOS Safari 제스처 끊김 | `play()` 내부에서 **동기 호출 체인** 유지 (async/await/setTimeout 금지) |
+| E3 | Chrome 15초 utterance 끊김 | 160자 chunk로 회피 (기존 `chunkText`) |
+| E4 | localStorage private mode 차단 | `try/catch` + in-memory fallback (`memoryFallback` 변수) |
+| E5 | 저장된 voiceURI 가 OS 업데이트 후 사라짐 | `pickBestVoice()` 의 fallback 체인 |
+| E6 | rate > 1.5 에서 scroll animation 어색 | Plan Phase B 고려. MVP는 smooth 유지 (prefers-reduced-motion 에서는 auto) |
+| E7 | 사용자가 재생 중 다음 블로그로 네비게이션 | `useEffect(() => () => speechSynthesis.cancel(), [])` |
+| E8 | 브라우저 탭 background | `visibilitychange` 리스너: hidden → pause, visible → resume (단, 사용자가 직접 paused 상태였다면 그대로 유지) |
+| E9 | Chrome `cancel()` 후 `onerror` event 발사 | `e.error === 'interrupted'` or `'canceled'` 는 무시 (정상 경로) |
+| E10 | `scrollIntoView` 가 user scroll 방해 | 2.5s cooldown (`userScrolledAtRef`) |
+| E11 | 같은 문단 내 여러 chunk 연속 재생 | `prevBlockIdxRef` 비교로 scroll 1회만 |
+| E12 | 코드블록이 `<p>` 안에 인라인으로 (MDX 오작성) | `el.closest('pre')` 로 방어. 인라인 `<code>` 는 textContent에 포함되어 읽힘 — 의도됨 |
+| E13 | 헤딩 내부 autolink `#` 문자 | `readableText()` 에서 `.heading-anchor` element 제거 |
+| E14 | 매우 긴 문단 (1000자+) | chunkText가 160자씩 분할. blockIndex 같으므로 scroll 1회. UX 영향 없음 |
+| E15 | 글 본문이 비어있는 경우 (draft?) | `chunks.length === 0` 이면 Play 버튼 disable + aria-disabled |
+| E16 | 키보드로 Play 버튼 focus 상태에서 Space | `<button>` 기본 동작. 별도 단축키 X (MVP 제외) |
+| E17 | Preferred voice 가 처음 없지만 나중에 로드 | `useVoices()` + `pickBestVoice()` 가 업데이트 시 재계산. selection이 null→value 로 바뀌면 UI 자동 반영 |
+
+---
+
+## 9. QA 검증 매트릭스
+
+### 9.1 자동 (Chrome MCP)
+
+| 항목 | 기대 | 방법 |
+|---|---|---|
+| /blog/{slug} 에서 "Listen" 버튼 렌더 | 1개 존재 | `document.querySelector('button[aria-label="Listen to article"]')` |
+| 버튼 클릭 후 controls 노출 | play/pause/speed/voice 모두 존재 | DOM query |
+| 클릭 후 `speechSynthesis.speaking === true` | true | 300ms wait 후 체크 |
+| 현재 문단에 `data-tts-active="true"` 부여됨 | 1개 element | `querySelectorAll('[data-tts-active]').length === 1` |
+| Pause 클릭 → `speechSynthesis.paused === true` | true | direct API 확인 |
+| Voice select → localStorage에 voiceURI 저장됨 | `localStorage['tene:blog-tts']` 에 voiceURI | |
+| 다른 글 navigate 시 이전 음성 종료 | `speechSynthesis.speaking === false` | route change 후 확인 |
+| Stop 후 highlight 해제됨 | `[data-tts-active]` 0개 | |
+
+### 9.2 수동 (실기기)
+
+| 브라우저 | OS | 항목 |
+|---|---|---|
+| Safari 17+ | macOS | 재생 + scroll follow + voice dropdown |
+| Chrome 130+ | macOS | 동일 + 15초 chunking 검증 (긴 문단) |
+| Firefox 130+ | macOS | 재생 + scroll follow (boundary 없음이지만 chunk 기반 sync 정상) |
+| Safari | iOS 17+ | 첫 play 제스처 + 백그라운드 시 pause |
+| Chrome | Android | 동일 |
+
+### 9.3 접근성
+
+- [ ] `<button>` aria-label
+- [ ] Speed/Voice select 에 `<label>`
+- [ ] 활성 문단에 focus 이동 X (screen reader 중복 방지)
+- [ ] `prefers-reduced-motion` 존중
+
+---
+
+## 10. 빌드/번들 검증
+
+### 10.1 사이즈 추정 (Agent B 분석)
+
+```
+TTSButton              0.5 KB
+TTSPlayer + hooks     ~7.5 KB
+chunks.ts              1.2 KB
+prefs.ts               1.0 KB
+voices.ts              0.8 KB
+CSS (globals)          0.3 KB
+──────────────────────────────
+Subtotal (uncompressed) ~11 KB
+Gzipped (~35%)          ~4 KB  ✅ Plan 목표 < 5 KB
+```
+
+### 10.2 Next.js 호환
+
+- Client component만 client bundle에 편입 (server PostHero 영향 없음)
+- SSR 에서 `typeof window === 'undefined'` 가드 전부 적용 (prefs.ts, voices.ts, hooks)
+- Code splitting: `TTSButton` → `TTSPlayer` lazy import 옵션 고려 (MVP 아님)
+
+### 10.3 CSP 호환
+
+Agent B 확인: `next.config.ts` CSP는 Web Speech API 미영향 (로컬 API, 외부 네트워크 요청 없음).
+
+---
+
+## 11. Phase B (MVP 외)
+
+- 단어 레벨 하이라이트 (`boundary` 이벤트, Safari/Chrome만)
+- 재생 위치 persist (slug + chunkIndex → localStorage)
+- 한국어 글 추가 시 다국어 voice auto-select
+- 모바일 floating mini-player
+- Callout/CopyCommand/Table 읽기 지원
+- 키보드 단축키 (Space, Esc, →/←)
+- 사용자 개입 감지 고도화 (wheel/touch 이벤트 분리)
+- 재생 속도 ≥ 1.75x 시 scroll animation `auto` 강제
+
+---
+
+## 12. 구현 순서 (Do Phase)
+
+1. `src/lib/track.ts` — EventMap 확장 (7개 이벤트 추가)
+2. `src/lib/tts/chunks.ts` — 순수 함수 + 테스트 가능한 형태
+3. `src/lib/tts/prefs.ts` — localStorage wrapper + SSR guard
+4. `src/lib/tts/voices.ts` — voices hook + filter/pick helpers
+5. `src/hooks/use-tts.ts` — 재생 lifecycle 훅
+6. `src/hooks/use-scroll-sync.ts` — scroll + highlight 훅
+7. `src/components/blog/tts-controls.tsx` — 순수 UI
+8. `src/components/blog/tts-player.tsx` — orchestrator
+9. `src/components/blog/tts-button.tsx` — 진입점
+10. `src/components/blog/post-hero.tsx` — TTSButton 통합 (1줄 추가)
+11. `src/app/globals.css` — `[data-tts-active]` 스타일
+12. Build + Chrome MCP QA
+13. 수동 cross-browser 확인 (macOS 3 브라우저 + iOS Safari)
+14. CHANGELOG + Report + PR staging
+
+---
+
+## 13. 참조
+
+- Plan: `docs/01-plan/blog-tts.plan.md`
+- /pdca team 리서치 2건 (이 세션):
+  - Agent A: scroll sync + localStorage 기술 상세
+  - Agent B: tene 코드베이스 통합 지점 + DOM 구조 매핑
+- 기존 파일:
+  - `src/app/blog/[slug]/page.tsx:129` — `<article className="min-w-0">` 컨테이너
+  - `src/components/blog/post-hero.tsx` — 서버 컴포넌트, 클라이언트 자식 import 지점
+  - `src/mdx-components.tsx:20-164` — 모든 MDX 요소 렌더러
+  - `src/components/blog/code-block-wrapper.tsx` — shiki 블록 구분용 `.shiki` class
+  - `src/lib/track.ts:6-55` — EventMap 확장 위치
+  - `src/app/globals.css:1-140` — CSS 변수 + 애니메이션 위치
+- ttsreader 엔진 참조: `github.com/RonenR/ttsreader` (패턴만, import 안 함)
+- Web Speech API: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
+- `scroll-margin-top`: https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top
+- `prefers-reduced-motion`: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+
+---
+
+**작성**: 2026-04-24 (Claude main, /pdca team 종합)
+**승인 대기**: 사용자 확인 후 Do Phase 진입. 수정 필요한 결정이 있으면 이 문서의 해당 section에 기록하고 Do 재개.

--- a/docs/02-design/features/release-pipeline-resilience.design.md
+++ b/docs/02-design/features/release-pipeline-resilience.design.md
@@ -1,0 +1,292 @@
+# Release Pipeline Resilience — Design
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `release-pipeline-resilience` |
+| Plan | `docs/01-plan/release-pipeline-resilience.plan.md` |
+| 브랜치 | `fix/release-pipeline-resilience` |
+
+---
+
+## 1. Release 파이프라인 현황 (As-Is)
+
+### 1.1 End-to-end 체인
+
+```
+사용자: git push main
+   │
+   ▼
+[auto-tag job]
+   - git tag 추출 (latest stable + latest rc)
+   - branch 별 next version 계산:
+     main   → v{major}.{minor}.{patch+1}  (stable)
+     staging → v{major}.{minor}.{patch+1}-rc1 (prerelease)
+   - gh api로 tag reference 생성 (Verified 뱃지 획득)
+   - outputs.version = 새 태그 이름
+   │
+   ▼
+[goreleaser job]
+   steps:
+     - Checkout at tag
+     - Setup Go / AWS OIDC / GHCR login / QEMU / Buildx
+     - Run GoReleaser (5 minute)
+       ├ builds (darwin/linux/windows × amd64/arm64)
+       ├ archives (tar.gz / zip)
+       ├ checksums
+       ├ homebrew formula generation
+       ├ dockers (GHCR push)
+       ├ publishing.blobs (S3 upload)   ← 바이너리 전파
+       ├ publishing.dockers (manifests)
+       ├ docker_digests
+       ├ scm.releases (GitHub Release)  ← 공개 시점
+       └ publishing.homebrew (태그 리포 push)  ← 401 실패 지점
+     - Update LATEST_VERSION (stable only)   ← 현재 이전 스텝 실패로 스킵됨
+```
+
+### 1.2 현재 `Update LATEST_VERSION` 스텝 (auto-tag.yml:150-158)
+
+```yaml
+- name: Update LATEST_VERSION (stable only)
+  if: "!contains(needs.auto-tag.outputs.version, '-rc')"
+  run: |
+    VERSION="${{ needs.auto-tag.outputs.version }}"
+    VERSION="${VERSION#v}"
+    echo "$VERSION" > /tmp/LATEST_VERSION
+    aws s3 cp /tmp/LATEST_VERSION s3://${{ env.RELEASE_BUCKET }}/LATEST_VERSION \
+      --content-type "text/plain" \
+      --cache-control "max-age=60"
+```
+
+**취약점**: `if:` 조건에 `always()` 가드가 없어서 GitHub Actions 기본 동작(이전 스텝 실패 시 subsequent step skip)에 노출. goreleaser가 `exit 1` 하면 이 스텝은 `skipped` 상태로 넘어감.
+
+### 1.3 현재 `brews:` 섹션 (.goreleaser.yml:91-120)
+
+```yaml
+brews:
+  - name: tene
+    ...
+    repository:
+      owner: tomo-kay
+      name: homebrew-tene                      # ← 존재하지 않는 리포
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"  # ← secret 미설정
+    skip_upload: auto                           # ← stable 릴리스에서는 skip 안 함
+    install: |
+      bin.install "tene"
+      bash_completion.install ...
+    ...
+```
+
+**취약점**: `homebrew-tene` 리포가 존재하지 않고 `HOMEBREW_TAP_GITHUB_TOKEN` secret도 없어서 매 stable 릴리스마다 401.
+
+## 2. 설계 (To-Be)
+
+### 2.1 Change #1 — `auto-tag.yml` 의 LATEST_VERSION 스텝 강화
+
+**Before**:
+```yaml
+- name: Update LATEST_VERSION (stable only)
+  if: "!contains(needs.auto-tag.outputs.version, '-rc')"
+  run: |
+    VERSION="${{ needs.auto-tag.outputs.version }}"
+    VERSION="${VERSION#v}"
+    echo "$VERSION" > /tmp/LATEST_VERSION
+    aws s3 cp /tmp/LATEST_VERSION s3://${{ env.RELEASE_BUCKET }}/LATEST_VERSION \
+      --content-type "text/plain" \
+      --cache-control "max-age=60"
+```
+
+**After**:
+```yaml
+- name: Update LATEST_VERSION (stable only)
+  # Runs even when GoReleaser exited non-zero on a non-critical step
+  # (e.g. Homebrew formula push hitting 401 when the tap repo is absent).
+  # Safeguard: refuse to flip the pointer unless the darwin/arm64 tarball
+  # for this version actually exists on S3 — that single artifact proves
+  # the `blobs:` publishing stage completed and the install.sh chain is
+  # serviceable.
+  if: always() && !contains(needs.auto-tag.outputs.version, '-rc')
+  run: |
+    VERSION="${{ needs.auto-tag.outputs.version }}"
+    VERSION="${VERSION#v}"
+    TARBALL="s3://${{ env.RELEASE_BUCKET }}/v${VERSION}/tene_${VERSION}_darwin_arm64.tar.gz"
+    if ! aws s3 ls "$TARBALL" > /dev/null 2>&1; then
+      echo "::error::Refusing to update LATEST_VERSION — $TARBALL not found on S3"
+      exit 1
+    fi
+    echo "$VERSION" > /tmp/LATEST_VERSION
+    aws s3 cp /tmp/LATEST_VERSION s3://${{ env.RELEASE_BUCKET }}/LATEST_VERSION \
+      --content-type "text/plain" \
+      --cache-control "max-age=60"
+    echo "::notice::LATEST_VERSION updated to ${VERSION}"
+```
+
+**변경 포인트**:
+1. `if:` 조건에 `always()` 추가 → 이전 스텝 실패에도 실행
+2. S3 tarball 존재 검증 추가 → 바이너리 없이 포인터 전진 방지
+3. `::error::` / `::notice::` GitHub annotation → workflow UI에서 명확한 결과 표시
+
+**엣지 케이스 커버**:
+| 시나리오 | 이전 동작 | 새 동작 |
+|---------|---------|---------|
+| 바이너리 upload 성공 → homebrew 단계만 실패 | skip → LATEST_VERSION 구버전 유지 | 실행 → 가드 통과 → LATEST_VERSION 신버전 |
+| 빌드 단계에서 실패 (바이너리 없음) | skip | 실행 → 가드 실패 → LATEST_VERSION 구버전 보존 (의도됨) |
+| rc tag | skip (변경 없음) | skip (변경 없음) |
+| 정상 (전부 성공) | 실행 | 실행 |
+
+### 2.2 Change #2 — `.goreleaser.yml` 의 `brews:` 섹션 비활성
+
+**Before**: 원본 코드 (위 1.3 참조)
+
+**After** (전체 주석 처리 + 복원 가이드):
+```yaml
+# Homebrew tap — currently disabled.
+#
+# Publishing to a Homebrew tap requires:
+#   1. A public GitHub repo `tomo-kay/homebrew-tene` to exist.
+#   2. A fine-grained PAT with `Contents: Read/Write` on that repo,
+#      stored as the `HOMEBREW_TAP_GITHUB_TOKEN` secret on this repo
+#      (tomo-kay/tene).
+#
+# Neither is set up yet, and three consecutive stable releases
+# (v1.0.5, v1.0.6, v1.0.7) failed on this block with a 401 that
+# skipped the downstream `Update LATEST_VERSION` step and left
+# install.sh pointing at a stale version.
+#
+# To re-enable:
+#   1. Create https://github.com/tomo-kay/homebrew-tene (public, MIT).
+#   2. Create the PAT and run:
+#        gh secret set HOMEBREW_TAP_GITHUB_TOKEN --repo tomo-kay/tene
+#   3. Uncomment the block below.
+#
+# brews:
+#   - name: tene
+#     homepage: "https://tene.sh"
+#     description: "Local-first encrypted secret manager CLI for AI-safe developer workflows"
+#     license: "MIT"
+#     repository:
+#       owner: tomo-kay
+#       name: homebrew-tene
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     directory: Formula
+#     commit_author:
+#       name: goreleaserbot
+#       email: bot@tene.sh
+#     commit_msg_template: "chore(tap): bump tene to {{ .Tag }}"
+#     skip_upload: false
+#     install: |
+#       bin.install "tene"
+#       bash_completion.install "completions/tene.bash" => "tene"
+#       zsh_completion.install "completions/_tene"
+#       fish_completion.install "completions/tene.fish"
+#       man1.install "manpages/tene.1"
+#     test: |
+#       system "#{bin}/tene", "version"
+#     caveats: |
+#       Get started:
+#         tene init
+#
+#       Documentation:
+#         https://github.com/tomo-kay/tene#readme
+#
+#       For AI agents using this project:
+#         https://tene.sh/llms.txt
+```
+
+**변경 포인트**:
+1. `brews:` 블록 전체 주석 처리
+2. 이유 + 복원 가이드 주석으로 명시
+3. `skip_upload: auto` → `skip_upload: false` 로 복원 시점에 명확한 동작 (혹시 모를 오해 방지)
+
+**goreleaser 동작 변화**:
+- `release --clean` 실행 시 brews 관련 phase 자체가 스킵 (config에 없음)
+- `scm releases` (GitHub Release) 이후 바로 완료
+- `homebrew formula` 단계의 `check default branch` 401이 발생할 일 자체가 없음
+
+### 2.3 Change #3 — `CHANGELOG.md` 의 Unreleased Fixed 엔트리
+
+```markdown
+### Fixed
+
+- `auto-tag.yml` workflow's `Update LATEST_VERSION` step now runs with
+  `if: always()` and a S3 tarball existence check. Previously a
+  non-critical GoReleaser failure (e.g. Homebrew formula publish) would
+  skip this step and leave `install.sh` users on a stale version —
+  v1.0.5, v1.0.6, and v1.0.7 each required a manual S3 hotfix.
+- Homebrew publishing disabled in `.goreleaser.yml` until the
+  `tomo-kay/homebrew-tene` tap repository and `HOMEBREW_TAP_GITHUB_TOKEN`
+  secret are set up. Re-enable instructions are preserved inline in the
+  `brews:` comment block.
+```
+
+## 3. 실행 순서 (Do Phase)
+
+1. `.github/workflows/auto-tag.yml` 의 `Update LATEST_VERSION` step 수정 (Change #1)
+2. `.goreleaser.yml` 의 `brews:` 블록 주석 처리 (Change #2)
+3. `CHANGELOG.md` Fixed 엔트리 추가 (Change #3)
+4. Single commit: `fix(release): always update LATEST_VERSION + disable Homebrew publish`
+5. Push → PR (base: staging)
+
+## 4. 비기능 관점 (NFR)
+
+### 4.1 보안
+- S3 tarball 존재 검증은 **OIDC 인증된 GitHub Actions runner**에서만 실행. 외부 접근 불가.
+- 가드 실패 시 step 자체가 exit 1 → workflow UI에서 명확한 에러 표시.
+
+### 4.2 관찰성
+- `::notice::LATEST_VERSION updated to ${VERSION}` annotation → workflow Summary에 성공 로그
+- `::error::Refusing to update...` annotation → 가드 실패 시 명확한 원인 표시
+
+### 4.3 복원 가능성
+- `.goreleaser.yml` 주석 블록에 활성화 단계 포함 → 6개월 뒤 사용자가 봐도 즉시 복원 가능
+- git log의 이 commit을 reference하면 의사결정 추적 가능
+
+## 5. QA 매트릭스 (Check Phase)
+
+### 5.1 정적 분석
+
+| 검증 | 명령 | 기대 |
+|---|---|---|
+| YAML 구문 | `yq '.' .github/workflows/auto-tag.yml > /dev/null` | exit 0 |
+| YAML 구문 | `yq '.' .goreleaser.yml > /dev/null` | exit 0 |
+| goreleaser config | `cd /tmp && git clone ... && goreleaser check` | "config is valid" |
+| brews 블록 부재 | `yq '.brews' .goreleaser.yml` | null |
+
+### 5.2 시나리오 매트릭스
+
+| 시나리오 | goreleaser 결과 | version | if 평가 | tarball 가드 | 최종 동작 |
+|---------|:-:|:-:|:-:|:-:|---|
+| stable, 정상 전체 | success | v1.0.8 | ✓ true | ✓ pass | LATEST_VERSION=1.0.8 |
+| stable, 바이너리 upload 후 non-critical 실패 | failure | v1.0.8 | ✓ true | ✓ pass | LATEST_VERSION=1.0.8 |
+| stable, 바이너리 upload 전 실패 | failure | v1.0.8 | ✓ true | ✗ fail | LATEST_VERSION 불변 + step exit 1 |
+| rc | any | v1.0.8-rc1 | ✗ false | N/A | step skip |
+
+### 5.3 운영 모니터링 (이번 사이클 외부)
+
+다음 stable 릴리스 시 확인:
+- Auto Tag & Release 전체 conclusion = success (brews 없어짐)
+- `Update LATEST_VERSION` step의 annotation 로그 확인
+- S3 `LATEST_VERSION` 파일 Last-Modified가 릴리스 시각과 일치
+
+## 6. 롤백 (Act Phase)
+
+### 6.1 이 fix 자체 문제 발생 시
+1. revert this commit
+2. push + PR
+3. 되돌린 상태에서 수동 S3 hotfix로 운영 계속
+
+### 6.2 Homebrew 재활성 (사용자 결정 시)
+이 fix와 관계없이 독립적으로:
+1. `gh repo create tomo-kay/homebrew-tene --public --license MIT --add-readme`
+2. Fine-grained PAT 발급 + `gh secret set HOMEBREW_TAP_GITHUB_TOKEN`
+3. `.goreleaser.yml` brews 블록 주석 제거
+4. 다음 stable 릴리스에서 자동 publish 확인
+
+---
+
+## 7. 참조
+
+- Plan: `docs/01-plan/release-pipeline-resilience.plan.md`
+- auto-tag.yml 현재: `tene/.github/workflows/auto-tag.yml:150-158`
+- goreleaser brews 현재: `tene/.goreleaser.yml:91-120`
+- install.sh 현재: `tene/apps/web/public/install.sh:39-47`
+- 과거 실패: GitHub Actions 24826937468, 24888395413, 24889443661

--- a/docs/03-report/release-pipeline-resilience-2026-04-24.md
+++ b/docs/03-report/release-pipeline-resilience-2026-04-24.md
@@ -1,0 +1,229 @@
+# Release Pipeline Resilience — Report
+
+| 항목 | 값 |
+|------|-----|
+| Feature | `release-pipeline-resilience` |
+| 기준일 | 2026-04-24 |
+| 브랜치 | `fix/release-pipeline-resilience` |
+| 관련 docs | `docs/01-plan/release-pipeline-resilience.plan.md`, `docs/02-design/features/release-pipeline-resilience.design.md` |
+| 소요 시간 | ~2h (Plan 25m + Design 30m + Do 15m + QA 20m + Report 20m + S3 hotfix 10m) |
+
+---
+
+## 1. 배경 — 왜 이 PDCA가 필요했나
+
+### 1.1 반복된 실패 패턴
+
+2026-04-22 ~ 2026-04-24 사이 안정 릴리스 **3회 연속 동일 실패**:
+
+| 릴리스 | 릴리스 시각 (UTC) | GoReleaser 결과 | S3 LATEST_VERSION 자동 갱신 |
+|:-:|:-:|:-:|:-:|
+| v1.0.5 | 2026-04-23 09:14 | ❌ failure (homebrew 401) | ❌ skip → 수동 hotfix |
+| v1.0.6 | 2026-04-24 12:00 | ❌ failure (homebrew 401) | ❌ skip → 수동 hotfix 필요 |
+| v1.0.7 | 2026-04-24 12:29 | ❌ failure (homebrew 401) | ❌ skip → 수동 hotfix |
+
+### 1.2 사용자 영향
+
+- **신규 사용자**: `curl ... | sh`로 설치 시 매번 구버전(최대 2버전 뒤) 다운로드
+- **운영자(사용자 본인)**: 매 릴리스마다 수동 S3 `aws s3 cp` 명령어 실행 필요
+- **인식 신뢰도**: GitHub Actions UI에 매번 빨간 "failure" 라벨 → 신규 기여자/외부 관찰자가 "유지 안 되는 프로젝트" 시그널로 해석 가능
+
+### 1.3 이전 시도 (PR #66, 2026-04-23)
+
+비슷한 워크플로우 fix 제안을 포함했지만 **homebrew 복원 작업과 묶어서** 제시 → 사용자가 "homebrew는 아직 고민할래"라며 PR close + 브랜치 삭제. 결과적으로 문제 방치.
+
+---
+
+## 2. 진단 (Plan Phase 결과)
+
+### 2.1 Two independent root causes
+
+| # | 원인 | 파일 | 증상 |
+|:-:|---|---|---|
+| A | `Update LATEST_VERSION` step에 `if: always()` 가드 없음 | `.github/workflows/auto-tag.yml:150-158` | goreleaser exit 1 → step skip |
+| B | `brews:` 섹션이 존재하지 않는 `tomo-kay/homebrew-tene` 리포 + 미설정 `HOMEBREW_TAP_GITHUB_TOKEN` secret 참조 | `.goreleaser.yml:91-120` | 매 stable 릴리스마다 401 Bad credentials |
+
+A는 B의 **결과 증폭**. B를 고치지 않아도 A를 고치면 LATEST_VERSION 자동 갱신은 보장됨. B도 함께 해소하면 workflow failure 라벨 자체가 사라짐.
+
+### 2.2 사용자 의도 (본 세션에서 확정)
+
+> "LATEST_VERSION 업데이트를 CICD에 항상 포함해야겠어. 그리고 homebrew는 아직 대응안할거야. 이점도 CICD 수정 필요한듯."
+
+→ 두 원인 모두 **동시에 해소**하기로 결정.
+
+---
+
+## 3. 실행 (Do Phase)
+
+### 3.1 Change #1 — `auto-tag.yml` LATEST_VERSION step 강화
+
+**파일**: `.github/workflows/auto-tag.yml`
+
+**변경 내용**:
+1. `if:` 조건에 `always()` 추가 → 이전 스텝 실패에 영향받지 않음
+2. S3 tarball 존재 검증 가드 추가 → 바이너리 없는데 포인터만 전진하는 사고 방지
+3. `::error::` / `::notice::` GitHub annotation 추가 → workflow Summary에서 결과 즉시 확인 가능
+4. 이 변경의 동기와 과거 사례를 5줄 주석으로 파일 내 보존
+
+**Before → After diff (요약)**:
+```diff
+- if: "!contains(needs.auto-tag.outputs.version, '-rc')"
++ if: always() && !contains(needs.auto-tag.outputs.version, '-rc')
+  run: |
+    VERSION="${{ needs.auto-tag.outputs.version }}"
+    VERSION="${VERSION#v}"
++   TARBALL="s3://${{ env.RELEASE_BUCKET }}/v${VERSION}/tene_${VERSION}_darwin_arm64.tar.gz"
++   if ! aws s3 ls "$TARBALL" > /dev/null 2>&1; then
++     echo "::error::Refusing to update LATEST_VERSION — $TARBALL not found on S3"
++     exit 1
++   fi
+    echo "$VERSION" > /tmp/LATEST_VERSION
+    aws s3 cp /tmp/LATEST_VERSION s3://${{ env.RELEASE_BUCKET }}/LATEST_VERSION \
+      --content-type "text/plain" \
+      --cache-control "max-age=60"
++   echo "::notice::LATEST_VERSION updated to ${VERSION}"
+```
+
+### 3.2 Change #2 — `.goreleaser.yml` brews 섹션 비활성
+
+**파일**: `.goreleaser.yml`
+
+**변경 내용**:
+- `brews:` 블록(30줄) 전체 주석 처리
+- 상단 14줄 주석으로 (a) 왜 disabled인지 (b) 3번 실패한 릴리스 레퍼런스 (c) 3단계 재활성 가이드 명시
+- 향후 재활성 시 `skip_upload: auto` → `skip_upload: false` 권장 기본값 변경 명시
+
+### 3.3 Change #3 — `CHANGELOG.md` Unreleased Fixed 엔트리
+
+2개 엔트리 추가:
+1. `auto-tag.yml` LATEST_VERSION 내구성 개선 (증상 + fix 설명)
+2. Homebrew publishing 일시 비활성 (이유 + 재활성 위치)
+
+---
+
+## 4. 검증 (QA Phase)
+
+### 4.1 정적 분석 (실행 완료)
+
+| 검증 | 결과 |
+|---|:-:|
+| `.github/workflows/auto-tag.yml` YAML 파싱 (Python `yaml.safe_load`) | ✅ 유효 |
+| `.goreleaser.yml` YAML 파싱 | ✅ 유효 |
+| `brews` top-level key가 `.goreleaser.yml`에서 사라졌는가 | ✅ None |
+| `Update LATEST_VERSION` step의 `if` 조건 | ✅ `always() && !contains(needs.auto-tag.outputs.version, '-rc')` |
+| tarball 존재 가드 코드 포함 | ✅ `TARBALL` + `aws s3 ls` 존재 |
+| GitHub notice annotation 포함 | ✅ `LATEST_VERSION updated to` 존재 |
+| `builds` / `archives` / `checksum` / `dockers` / `docker_manifests` / `blobs` 섹션 영향 없음 | ✅ 모두 정상 파싱 |
+
+### 4.2 시나리오 매트릭스 (설계 시점 예상)
+
+| 시나리오 | goreleaser 결과 | version | `if` 평가 | tarball 가드 | 최종 동작 |
+|---------|:-:|:-:|:-:|:-:|---|
+| 정상 (이상적) | success | v1.0.8 | ✅ true | ✅ pass | LATEST_VERSION=1.0.8 자동 갱신 |
+| **현재 주된 시나리오** — 바이너리 upload 후 homebrew 실패 | failure | v1.0.8 | ✅ true | ✅ pass | LATEST_VERSION=1.0.8 자동 갱신 ✨ |
+| 빌드/upload 전 실패 (바이너리 없음) | failure | v1.0.8 | ✅ true | ❌ fail | exit 1 + ::error::, LATEST_VERSION 불변 (보호) |
+| rc 태그 (모든 경우) | any | v1.0.8-rc1 | ❌ false | N/A | skip (변경 없음) |
+| workflow 취소 | cancelled | any | `always()` 특성상 try | 실제로는 runner 취소 시 step 미실행 | 영향 없음 |
+
+### 4.3 운영 검증 (PDCA 외부 — 다음 릴리스 시 모니터링)
+
+다음 stable 릴리스(v1.0.8 예상) 시 확인 항목:
+1. `brews:` 없어져서 goreleaser exit 0 (homebrew formula step 자체 실행 안 됨)
+2. Auto Tag & Release workflow conclusion = **success** (3개월 만에 처음)
+3. S3 `LATEST_VERSION` 자동 갱신 Last-Modified가 릴리스 시각과 일치
+4. `install.sh` 스크립트가 최신 버전을 즉시 다운로드
+5. 수동 S3 hotfix **불필요**
+
+---
+
+## 5. 효과 (Act Phase 측정 예정)
+
+### 5.1 측정 가능한 효과
+
+| 지표 | Before (최근 3회 릴리스 평균) | After (목표) | 영향 |
+|---|:-:|:-:|---|
+| 릴리스 후 수동 개입 (분) | 10-15 | **0** | 릴리스당 ~12분 절약 |
+| Auto Tag & Release workflow 성공률 | 0/3 (0%) | 예상 3/3 (100%) | UI 신호 정상화 |
+| install.sh 구버전 노출 기간 | 길게는 1일+ | **< 1분** (S3 전파) | 신규 사용자 영향 제거 |
+| Homebrew publish | ❌ 설정은 있으나 항상 실패 | ⏸ 명시적 보류 (문서화) | 의사결정 투명성 |
+
+### 5.2 비의도적 부작용 (없음 예상)
+
+- `dockers:`, `blobs:`, `scm releases` 등 다른 블록 영향 없음 (YAML 파싱 확인)
+- 기존 v1.0.5-v1.0.7 릴리스의 이미 배포된 아티팩트(S3 바이너리, GHCR Docker)는 불변
+- 복원 시점에 정확히 어떻게 되돌릴지 `.goreleaser.yml` 내부 가이드로 보존
+
+---
+
+## 6. 잔여 리스크 & 관찰 지점
+
+### 6.1 모니터링 대상
+
+- **다음 stable 릴리스 1회** — 이 fix의 실제 효과 검증. Auto Tag & Release conclusion 확인.
+- **S3 LATEST_VERSION 가드 false positive** — 만약 goreleaser가 탁월한 경로로 바이너리는 업로드했지만 다른 경로로 실패한다면? 현재 가드는 darwin/arm64 1개 파일만 검사. 5개 플랫폼 전체 검증까지는 안 함. **트레이드오프**: 완전 검증은 복잡, 단일 플랫폼은 빠름. 필요 시 후속.
+
+### 6.2 보류 (의도적)
+
+- Homebrew 재활성 — 사용자 결정 대기
+  - `tomo-kay/homebrew-tene` 저장소 생성
+  - `HOMEBREW_TAP_GITHUB_TOKEN` secret 설정
+  - `.goreleaser.yml` brews 주석 제거
+- Staging goreleaser 17분 hang 이슈 (2026-04-24 12:27:37 시작) — 본 fix와 무관한 GitHub Runner 이슈로 추정. main이 staging rc를 승격한 race condition 가능성. 재발 시 별도 조사.
+
+### 6.3 장기 개선 후보 (이번 스코프 외)
+
+- Slack/Discord 알림 연동 (release 성공/실패 시)
+- `install.sh`에 `LATEST_VERSION` 파일 정합성 fallback (GitHub API 조회)
+- cron sync workflow (hourly reconcile between GitHub latest release ↔ S3 LATEST_VERSION)
+- Staging 릴리스에서 goreleaser 생략 (rc publish 자체가 필요한지 재평가)
+
+---
+
+## 7. 파일 변경 요약
+
+| 파일 | 유형 | 변경 |
+|---|:-:|---|
+| `.github/workflows/auto-tag.yml` | 수정 | Update LATEST_VERSION step: `if: always()` + tarball guard + annotations |
+| `.goreleaser.yml` | 수정 | `brews:` 블록 주석 처리 + 재활성 가이드 |
+| `CHANGELOG.md` | 수정 | Unreleased > Fixed 2 entries 추가 |
+| `docs/01-plan/release-pipeline-resilience.plan.md` | 신규 | Plan 문서 |
+| `docs/02-design/features/release-pipeline-resilience.design.md` | 신규 | Design 문서 |
+| `docs/03-report/release-pipeline-resilience-2026-04-24.md` | 신규 | 본 보고서 |
+
+**코드 변경 규모**: 3개 파일, +53 / -39 줄 (워크플로우 + goreleaser + CHANGELOG 합산).
+
+---
+
+## 8. 배포 계획
+
+1. 본 브랜치 (`fix/release-pipeline-resilience`) push
+2. PR → `staging` 생성 + merge (CI 통과)
+3. `staging` → `main` PR + merge
+4. main merge → auto-tag이 v1.0.8 생성 → goreleaser 실행
+5. **관찰 지점**: 이 시점에서 fix가 실제로 작동하는지 확인. 3회 연속 실패 패턴이 깨지는지.
+
+---
+
+## 9. 참조
+
+- Plan: `docs/01-plan/release-pipeline-resilience.plan.md`
+- Design: `docs/02-design/features/release-pipeline-resilience.design.md`
+- 실패 로그 (GitHub Actions runs):
+  - 24826937468 (v1.0.5)
+  - 24888395413 (v1.0.6)
+  - 24889443661 (v1.0.7)
+- S3 수동 hotfix 이력 (이 보고서 기준 가장 최근):
+  - 2026-04-23 11:06:48 UTC — 1.0.4 → 1.0.5
+  - 2026-04-24 12:50:03 UTC — 1.0.5 → 1.0.7
+- 이전 시도 PR #66 (close됨, 2026-04-23)
+
+---
+
+**PDCA 사이클 요약**:
+- Plan: ✅ 2개 원인 진단 + 4개 옵션 평가 후 각 1개 선택
+- Design: ✅ diff 레벨 설계 + 엣지 케이스 매트릭스
+- Do: ✅ 3개 파일 수정
+- Check (QA): ✅ YAML 유효성 + 키 제거 검증 + 시나리오 매트릭스 정적 평가
+- Act: ⏸ 다음 stable 릴리스에서 실측 검증 (PDCA 외부)
+
+**작성**: 2026-04-24 (Claude main, 사용자 요청 PDCA 전주기 단일 세션)


### PR DESCRIPTION
## Summary

Promote staging to main. Two merged feature PRs + one hotfix PR:

### PR #71 — Release pipeline resilience (merged earlier)
- \`auto-tag.yml\` \`Update LATEST_VERSION\` step now runs with \`if: always()\` + S3 tarball-existence guard. Fixes the three consecutive v1.0.5/1.0.6/1.0.7 releases where \`install.sh\` users stayed on a stale version after Homebrew publish 401'd.
- \`.goreleaser.yml\` \`brews:\` block commented out with inline re-enable guide (Homebrew publishing paused until the tap repo is set up).

### PR #72 — Web Speech API TTS player
- Zero-cost "Listen" button on every article (\`speechSynthesis\`, no external provider).
- Chunked sentence playback (~160 chars) to dodge Chrome's 15-second utterance bug.
- Auto-scroll + accent-colored paragraph highlight during playback, with a 2.5 s cooldown on user scroll intervention.
- Voice + rate persisted via \`localStorage (tene:blog-tts)\`.
- Voice dropdown curated to 8 natural voices (macOS 5 + Google 3) — novelty voices like Bells/Bubbles/Zarvox stripped out, compact+premium duplicates de-deduped.
- Code block background parity fix (outer \`<pre>\` and inner \`<code>\` now match; MDX \`code\` renderer detects multi-line blocks even without a language tag; globals.css defense-in-depth).
- \`article pre > code\` transparent-bg rule added.

### Docs updates
- \`.claude/rules/blog-content.md\` — §6.1 "Fenced block visual contract" + §13 "Auto-generated features" (TTS guidance, breadcrumb, JSON-LD, related-posts, taxonomy auto-registration).
- \`.claude/rules/blog-pdca-workflow.md\` — Phase 3 self-check adds a grep-based gate against language-less fences.
- \`.claude/templates/blog/pre-publish-checklist.md\` — 48 → 49 checks (fenced-block language tag).

## Test plan
- [x] staging CI passed
- [x] staging Chrome MCP verification — Listen button mounts, 149 chunks extracted, inline-style highlight applied, localStorage persists across reload
- [x] Curated voice dropdown — 210 → 8 (Samantha, Karen, Moira, Aaron, Daniel, + 3 Google)
- [x] Code block backgrounds match on ai-agents org chart + 3 bkit code blocks
- [ ] Main production deploy — verify \`install.sh\` auto-updates (from the PR #71 workflow fix) when the next release fires
- [ ] Spot check tene.sh/blog/* TTS in a real browser with audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)