### PR TITLE
feat(blog) + fix(ci+infra): ax-philosophy + LATEST_VERSION pipeline fix

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -158,24 +158,25 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ needs.auto-tag.outputs.version }}
 
       - name: Update LATEST_VERSION (stable only)
-        # Runs even when GoReleaser exited non-zero on a non-critical step
-        # (e.g. Homebrew formula push hitting 401 when the tap repo is
-        # absent). Safeguard: refuse to flip the pointer unless the
-        # darwin/arm64 tarball for this version actually exists on S3 —
-        # that single artifact proves the `blobs:` publishing stage
-        # completed and the install.sh chain is serviceable.
+        # Safeguard: refuse to flip the pointer unless the darwin/arm64
+        # tarball for this version actually exists on S3 — that single
+        # artifact proves the `blobs:` publishing stage completed and
+        # the install.sh chain is serviceable.
         #
-        # Prior to 2026-04-24 this step did not have `if: always()` and
-        # three consecutive stable releases (v1.0.5, v1.0.6, v1.0.7)
-        # required a manual S3 hotfix because the step was skipped after
-        # the Homebrew step failed.
+        # Uses `aws s3api head-object` (requires s3:GetObject only) instead
+        # of `aws s3 ls` (which silently AccessDenies without s3:ListBucket
+        # bucket-level permission). The previous `s3 ls` form caused every
+        # stable release v1.0.5 through v1.0.8 to fail this guard despite
+        # the tarball being present — root cause documented in issue #74.
         if: always() && !contains(needs.auto-tag.outputs.version, '-rc')
         run: |
           VERSION="${{ needs.auto-tag.outputs.version }}"
           VERSION="${VERSION#v}"
-          TARBALL="s3://${{ env.RELEASE_BUCKET }}/v${VERSION}/tene_${VERSION}_darwin_arm64.tar.gz"
-          if ! aws s3 ls "$TARBALL" > /dev/null 2>&1; then
-            echo "::error::Refusing to update LATEST_VERSION — $TARBALL not found on S3"
+          KEY="v${VERSION}/tene_${VERSION}_darwin_arm64.tar.gz"
+          if ! aws s3api head-object \
+              --bucket "${{ env.RELEASE_BUCKET }}" \
+              --key "$KEY" > /dev/null 2>&1; then
+            echo "::error::Refusing to update LATEST_VERSION — s3://${{ env.RELEASE_BUCKET }}/${KEY} not on S3 (or s3:GetObject missing on tene-prod-github-actions role — see issue #74)"
             exit 1
           fi
           echo "$VERSION" > /tmp/LATEST_VERSION

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -3,6 +3,16 @@ name: Auto Tag & Release
 on:
   push:
     branches: [staging, main]
+    # Web/docs-only changes must NOT trigger a CLI version bump.
+    # The CLI is versioned by changes to source, build config, or this
+    # workflow itself — not by landing-page or blog content.
+    paths-ignore:
+      - 'apps/web/**'
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
 
 permissions:
   contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,14 +36,14 @@ builds:
 
 archives:
   - id: tene-archive
-    builds:
+    ids:
       - tene
-    format: tar.gz
+    formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - src: completions/*
         dst: completions

--- a/apps/web/content/blog/ax-redesign-not-ai-tools.mdx
+++ b/apps/web/content/blog/ax-redesign-not-ai-tools.mdx
@@ -1,0 +1,162 @@
+---
+slug: ax-redesign-not-ai-tools
+title: "AX is not AI tool adoption — it is organizational redesign"
+description: "The 5% capturing AI value at scale redesigned roles, workflows, governance, data, and KPIs before picking a model. The 95% in pilot purgatory did not."
+publishedAt: "2026-04-28"
+updatedAt: "2026-04-28"
+category: philosophy
+tags: ["workflow", "harness-engineering", "founder-story", "deep-dive"]
+author: "tomo-kay"
+cover: "/og-image.png"
+canonicalUrl: "https://tene.sh/blog/ax-redesign-not-ai-tools"
+faqs:
+  - question: "Is AX just rebranded digital transformation?"
+    answer: "Digital transformation moved paper-based processes online. AX redistributes decision rights between humans and software that can decide on its own. DT produced systems-of-record; AX produces operating models. The deliverable is different — and so is the failure mode."
+  - question: "What is the smallest unit of 'AI-native' that is still meaningful?"
+    answer: "A single workflow where the human role has shifted from execution to intent-and-approval and the AI role is execution-and-verification, with both halves logged and reviewable. Not a department, not a company — one workflow at a time. Stack them."
+  - question: "How long does AX actually take?"
+    answer: "The McKinsey 'AI high performers' who attribute 5%+ of EBIT to AI typically spent 2–3 years on workflow redesign, not 2–3 quarters on pilots. The 95% stuck in pilot purgatory have often been there for over 18 months. Speed comes from compounding decisions, not from buying faster models."
+  - question: "Does this require firing people?"
+    answer: "The data points the other way: high performers are roughly 2× more likely to invest in ambitious upskilling. Roles shift rapidly; headcount shifts lag and depend on growth, not on AI itself. Organizations that fire first usually lose institutional context faster than they gain AI leverage."
+---
+
+## The wrong question every executive is asking
+
+Every executive looking at AI in 2026 is asking the wrong question. They ask "which model should we buy", "which copilot wins", "build or partner". The companies that actually captured value spent eighteen months on a different question entirely: what does our organization look like when AI is a teammate, not a tool?
+
+The data is now in, and it is harsh. BCG's 2025 global analysis found that only 5% of organizations are achieving AI value at scale. McKinsey's 2025 State of AI report found that while 88% of organizations use AI in at least one function, only 1% describe their rollouts as mature. MIT's 2025 study put the figure even more bluntly: 95% of generative AI pilots failed to impact profit and loss. The gap between "we tried AI" and "AI changed how we operate" is the entire story.
+
+## The 95% / 5% gap
+
+The pattern across MIT, BCG, McKinsey, and Wharton research converges on a single sentence: transformation fails when it is treated as a technology rollout. The phrase "pilot purgatory" describes what this looks like in practice — almost every Fortune 500 company has a successful 50-person AI pilot, and very few can point to a deployment that pays for itself.
+
+The 5% who escaped did one thing the 95% did not. They redesigned the work before they picked the model.
+
+McKinsey's 2026 segmentation makes this concrete: AI high performers — roughly 6% of respondents who attribute more than 5% of EBIT to AI — are 2.8 times more likely than the rest to have fundamentally redesigned end-to-end workflows. Fifty-five percent of high performers redesigned workflows; only twenty percent of everyone else did. The variable is not budget, headcount, or model choice. It is whether the organization changed shape.
+
+## What fundamental redesign actually means
+
+Redesign is not a slogan. It is a measurable shift in five places: roles, workflows, governance, data, and KPIs. Skipping any of the five is how organizations end up in the 95%.
+
+The role shift is the most visible. In legacy organizations, humans write, build, run, and review. In AI-native organizations, humans set intent, approve, and own outcomes; AI executes, verifies, iterates, and optimizes.
+
+| Legacy role | AX-native role |
+|---|---|
+| Planner / PM | Problem-definer, context designer |
+| Engineer | Reviewer of AI output, architect |
+| Manager | Approver, KPI owner |
+| Executive | Designer of operating principles + accountability structure |
+
+The promotion criterion stops being "who shipped the most" and becomes "who gave the better context and the better judgment." That is not a soft change. It changes who is hired, who is promoted, and what a 1:1 actually discusses.
+
+## From bolt-on to AI-native workflows
+
+Most organizations bolt AI onto existing flows. The PRD is still written by a human. The code is partly AI-assisted. The review is still a human gate. The approval chain is unchanged. The result is a marginally faster version of the same flow — and the same bottlenecks, the same handoffs, the same political seams.
+
+AI-native workflows look different at the seams:
+
+```text
+Legacy:
+  human writes spec → human builds → human reviews → human approves
+                        (AI bolted in here, marginal speedup)
+
+AX-native:
+  human defines problem
+    → AI generates spec/draft/options
+    → human selects + approves
+    → AI implements + verifies
+    → human signs off on outcome
+    → result + log feed back as context for next loop
+```
+
+The second flow has fewer human steps, but every remaining human step carries more weight. The human is no longer typing — they are choosing among generated options, approving execution, and owning the outcome. The AI is no longer suggesting — it is doing the work and proving it works.
+
+That asymmetry is the whole point. It is also why bolting AI onto a legacy flow looks unimpressive: the bolt-on preserves the slowest part of the org while accelerating the part that was never the bottleneck.
+
+## Governance is the steering wheel, not the brake
+
+Once AI is making decisions, every decision needs a name attached. The most common framing — "governance slows AI down" — has it backwards. Governance is what lets AI go fast safely. Without it, the organization either stalls (no one will sign off on production deployment) or breaks (something ships that no one owns).
+
+A workable AX governance layer answers five questions for every AI-touched workflow:
+
+- Who approves the output?
+- What data is the AI allowed to see?
+- Which model has which permission scope?
+- Where is the result logged and retained?
+- Who is accountable when it goes wrong?
+
+<Callout type="warn">
+The EU AI Act becomes fully enforceable on August 2, 2026. Organizations that have not answered the five governance questions for their AI-touched workflows by then are not just running technical risk — they are running regulatory risk. Pilot purgatory is no longer a neutral place to sit.
+</Callout>
+
+The governance layer is also where the failure of "AI as a tool purchase" becomes visible. ERP and SaaS can be governed by IT alone. AI cannot — because the system makes decisions that legal, product, HR, and customer-facing teams will all answer for. Governance has to be cross-functional or it is ceremonial.
+
+## The data quality reality check
+
+Gartner finds that 85% of AI projects fail because of poor data quality. The McKinsey takeaway puts it the other way: high performers spend roughly $5 on people and process for every $1 on technology. The 80/20 split between data work and model work is not a phase. It is the steady state.
+
+The medical-AI version of this is now widely cited: a model that scored 87% accuracy on clean test data dropped to 34% in production, not because the model regressed but because 40% of the diagnostic codes were missing in the data the system actually saw. The lesson generalizes. AI does not improve bad data; it amplifies it, faster, with confident-sounding outputs.
+
+The discipline emerging around this in 2026 has a name: **context engineering**. The premise is that prompt engineering is necessary but not sufficient — what matters is what the model sees, in what order, with what permissions, and what record it leaves behind. Organizations that treat context as a first-class artifact (versioned, reviewed, owned by a named person) outscale organizations that treat prompts as a private skill.
+
+## KPIs that reward systems, not labor
+
+The KPIs most organizations carry into AI adoption are labor-volume KPIs: number of tickets closed, hours logged, headcount deployed. These metrics make AI invisible — or worse, punish the team that uses AI to do more with fewer people.
+
+| Legacy KPI | AX-native KPI |
+|---|---|
+| Number of items shipped | Time-to-problem-definition |
+| Hours worked | Output reproducibility rate |
+| Headcount on a project | Approval-to-iteration ratio |
+| Tickets closed | Quality of accumulated context |
+| Manager headcount | % of failures fed back into next cycle |
+
+The shift is from labor volume to system quality and organizational learning. The team that ships ten ticket fixes by hand is not better than the team that ships eight by hand and turns the other two into a recurring automation that closes future tickets without human involvement. Old KPIs flatten that distinction. AX-native KPIs surface it.
+
+## Why most AX transformations fail
+
+Across consultancy reports, post-mortems, and academic studies, the failure modes converge on five patterns:
+
+- **PoC stays a PoC.** A 50-person pilot succeeds, gets a demo, never scales because the operating model around it never changed.
+- **Function silos.** IT secures, business adopts, data builds models, exec demands ROI — no one owns the seam, so the seam fails.
+- **AI treated as tool purchase.** Licenses, training, "rollout complete" — without role, KPI, and approval changes, the field reverts to the old way within a quarter.
+- **No people story.** Frontline staff are not told what changes for them, why, and how their accountability is protected. Resistance is rational and predictable.
+- **Culture not aligned.** AI is adopted, but reports are still rewritten by hand, late nights still get rewarded, failure-sharing still gets punished. The behavior the metrics reward is what the organization actually does.
+
+Note what is missing from the list. None of these are model problems. None are inference-cost problems. They are organizational design problems wearing technology costumes.
+
+## One operating model that works
+
+A concrete picture is more useful than another framework. Here is one operating model that has held up across product, engineering, sales, and operations work, run as the daily reality at Popup Studio.
+
+In a Popup Studio meeting, AI is a participant from minute one. As the conversation unfolds, the team issues live instructions:
+
+```text
+"AI, summarize the last 10 minutes into a decision log."
+"AI, draft the spec for what we just agreed on."
+"AI, surface the three customer cases that match this pattern."
+"AI, generate three implementation options with tradeoffs."
+```
+
+By the end of the meeting, the spec, the decision log, the three options, and the customer references already exist. The humans in the room spent their hour on judgment — choosing direction, weighing risk, balancing the team — not on producing artifacts. Meeting count goes down. Meeting density goes up.
+
+The principle behind it is simple to state and hard to live by:
+
+> Every task starts as an instruction to AI. Humans only do thinking and judgment.
+
+When the boundary is that clear, the friction inside the team drops. People stop fighting over who has to take notes, write the doc, format the deck. They start fighting over what is actually worth deciding. Resistance to AI does not get argued away — it disappears the first time a teammate sees an hour come back to them at the end of a meeting.
+
+That is the experiential proof. It is also the only proof that scales: AI adoption sticks when it gives time back, not when leadership insists.
+
+## Summary
+
+- The 5% who capture AI value at scale redesigned roles, workflows, governance, data, and KPIs *before* picking a model. The 95% in pilot purgatory did not.
+- Governance is the steering wheel, not the brake. Without it, organizations either stall or ship things no one owns. The EU AI Act August 2026 deadline removes the option of waiting.
+- AI does not improve bad data — it amplifies it. Spend the $5 on people and process for every $1 on technology, or the model layer will not matter.
+- Replace labor-volume KPIs with system-quality KPIs. The team that automates two tickets is not weaker than the team that hand-fixes ten — old metrics just make it look that way.
+- The smallest unit of AX is one workflow where humans do intent + approval and AI does execution + verification, both logged. Stack workflows. Compound the system. Stop buying tools.
+
+Related reading:
+- [AI agents, human responsibility, and the harness in between](/blog/ai-agents-and-human-responsibility)
+- [bkit + harness engineering: workflow beats model choice](/blog/bkit-harness-engineering-vibe-coding)
+- [bkit: PDCA methodology for Claude Code](/blog/bkit-pdca-for-claude-code)


### PR DESCRIPTION
## Summary

Three changes bundled in one PR:

### 1. New blog article (1,851 words)
**\`/blog/ax-redesign-not-ai-tools\`** — Philosophy-category deep-dive synthesizing the author's original Korean essay with verified 2026 data from McKinsey, BCG, MIT, Deloitte, and Gartner. Thesis: AX is organizational redesign, not AI tool adoption. The 5% capturing AI value at scale redesigned roles/workflows/governance/data/KPIs *before* picking a model; the 95% in pilot purgatory did not.

### 2. CI: scope auto-tag trigger to CLI changes (\`paths-ignore\`)
Web/docs-only PRs (blog posts, README tweaks, install.sh edits) no longer trigger \`Auto Tag & Release\`. Path-matching simulation across 7 scenarios confirms intent.

### 3. CI: fix LATEST_VERSION guard (closes #74)
Switched from \`aws s3 ls\` (silently AccessDenies without \`s3:ListBucket\`) to \`aws s3api head-object\` (needs only \`s3:GetObject\`). Issue #74 documented the silent failure on every stable release v1.0.5–v1.0.8 — they all required manual S3 hotfix because the guard structurally could not succeed under the existing role permissions.

Also migrated \`.goreleaser.yml\` off three v2 deprecations (\`archives.builds\`/\`format\`/\`format_overrides.format\`) before they become hard errors in goreleaser v3.

**IAM policy update applied** (separate audit trail, not in PR diff): \`tene-prod-github-actions\` role inline policy \`s3-release-upload\` now contains both \`S3ReleaseUpload\` (PutObject + PutObjectAcl) and \`S3ReleaseVerify\` (GetObject) statements, both scoped to \`arn:aws:s3:::tene-releases/*\`. Verified via \`aws s3api head-object\` smoke test on existing v1.0.9 tarball.

## Validation

### Blog article
- BlogPosting + FAQPage JSON-LD ✓ · Canonical ✓ · 10 h2 with rehype-slug ✓
- 2 markdown tables · 1 Callout(warn) · 2 fenced text blocks · 4 FAQ pairs ✓
- Index/category/tag/RSS/sitemap fan-outs all confirmed
- Layout contract from \`.claude/rules/blog-content.md §7.1\` passes

### Workflow + goreleaser
- Both YAML files: \`yaml.safe_load\` valid
- 7-scenario \`paths-ignore\` simulation: trigger when (CLI source / mixed / workflow yaml itself), skip when (blog-only / docs-only / install.sh-only)
- IAM policy diff: only \`S3ReleaseVerify\` statement added — minimal scope, no \`ListBucket\` (which would be bucket-wide enumeration)
- \`head-object\` smoke test under new policy: ContentLength 5,109,138 returned for v1.0.9 darwin/arm64 ✓

## Note for reviewer

This PR's merge to staging will trigger Auto Tag once (workflow yaml + goreleaser yaml changes are in the diff, not in paths-ignore). The first stable release after this merges (\`v1.0.10\`) will exercise the new \`head-object\` guard end-to-end against the new IAM policy — that is the actual fix verification.

After that, blog-only / docs-only / install.sh-only PRs will not trigger Auto Tag at all (paths-ignore takes effect from this PR's merge onward).

## Self-correction

The earlier \`paths-ignore\` commit message referenced a "GoReleaser blobs/LATEST_VERSION race condition" — that hypothesis was **wrong**. Issue #74's IAM permission analysis is correct. The 35-second gap between blob upload and guard execution rules out timing as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)