### PR TITLE
fix(seo): resolve duplicate FAQPage JSON-LD on /blog and /vs pages

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -148,85 +148,10 @@ const jsonLd = {
       },
       publisher: { "@id": "https://tene.sh/#organization" },
     },
-    {
-      "@type": "FAQPage",
-      mainEntity: [
-        {
-          "@type": "Question",
-          name: "What is Tene?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Tene is a local-first, encrypted secret management CLI. It stores your API keys, tokens, and credentials in an encrypted SQLite vault on your device. No server, no signup, no cloud dependency.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "How does Claude Code auto-detection work?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "When you run tene init, it generates a CLAUDE.md file in your project root. Claude Code reads this file automatically and learns how to use tene to retrieve secrets.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Is Tene free?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Yes, Tene is 100% free and open source under the MIT license. All local features — encryption, runtime injection, multi-environment, AI editor rules — are free forever with no limits.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Will there be team features?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Team sync and collaboration features are being designed. The goal is encrypted team sync without a central server. Join the waitlist at tene.sh to get notified when it launches.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "How are my secrets encrypted?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Tene uses XChaCha20-Poly1305 encryption with 256-bit keys derived from your master password via Argon2id. Each secret gets a unique 192-bit nonce.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Does Tene work offline?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Tene is 100% offline. It makes zero network calls. Your secrets are encrypted and stored locally in a SQLite database.",
-          },
-        },
-      ],
-    },
-    {
-      "@type": "HowTo",
-      name: "How to use Tene for secret management",
-      step: [
-        {
-          "@type": "HowToStep",
-          name: "Install",
-          text: "Run: curl -sSfL https://tene.sh/install.sh | sh — or download from GitHub Releases (github.com/tomo-kay/tene/releases)",
-        },
-        {
-          "@type": "HowToStep",
-          name: "Initialize",
-          text: "Run tene init to create an encrypted vault and generate context files for Claude, Cursor, Windsurf, Gemini, and Codex.",
-        },
-        {
-          "@type": "HowToStep",
-          name: "Store secrets",
-          text: "Run tene set KEY value to encrypt and store secrets locally.",
-        },
-        {
-          "@type": "HowToStep",
-          name: "Develop with secrets",
-          text: "Run tene run -- your-command to inject secrets as environment variables.",
-        },
-      ],
-    },
+    // FAQPage + HowTo intentionally moved to <HomeJsonLd /> (rendered only
+    // on `/`). Emitting them in the root layout duplicated FAQPage on every
+    // /blog/{slug} and /vs/{slug} page, which GSC flags as "FAQPage 입력란
+    // 중복" and drops from rich results. Site-wide entities only here.
   ],
 };
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,10 +10,13 @@ import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
 import { FAQ } from "@/components/faq";
 import { InteractiveGrid } from "@/components/interactive-grid";
+import { HomeJsonLd } from "@/components/seo/home-jsonld";
 
 export default function Home() {
   return (
     <>
+      <HomeJsonLd />
+
       {/* Canvas-based interactive dot grid (desktop only) */}
       <InteractiveGrid />
 

--- a/apps/web/src/components/seo/home-jsonld.tsx
+++ b/apps/web/src/components/seo/home-jsonld.tsx
@@ -1,0 +1,103 @@
+// Home-only JSON-LD: FAQPage + HowTo. These are page-specific schemas that
+// describe content rendered on `/`, so they must NOT live in the root
+// layout (which emits on every page). When emitted globally they collide
+// with article-level FAQPage on /blog/{slug} and comparison FAQPage on
+// /vs/{slug} — GSC flags the duplicate as "FAQPage 입력란이 중복" and
+// drops the rich result.
+//
+// Site-wide entities (Organization, WebSite, SoftwareApplication) stay in
+// `layout.tsx` because they are `@id`-keyed and reused across pages.
+
+const homeJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "FAQPage",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "What is Tene?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Tene is a local-first, encrypted secret management CLI. It stores your API keys, tokens, and credentials in an encrypted SQLite vault on your device. No server, no signup, no cloud dependency.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "How does Claude Code auto-detection work?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "When you run tene init, it generates a CLAUDE.md file in your project root. Claude Code reads this file automatically and learns how to use tene to retrieve secrets.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Is Tene free?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Yes, Tene is 100% free and open source under the MIT license. All local features — encryption, runtime injection, multi-environment, AI editor rules — are free forever with no limits.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Will there be team features?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Team sync and collaboration features are being designed. The goal is encrypted team sync without a central server. Join the waitlist at tene.sh to get notified when it launches.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "How are my secrets encrypted?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Tene uses XChaCha20-Poly1305 encryption with 256-bit keys derived from your master password via Argon2id. Each secret gets a unique 192-bit nonce.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Does Tene work offline?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Tene is 100% offline. It makes zero network calls. Your secrets are encrypted and stored locally in a SQLite database.",
+          },
+        },
+      ],
+    },
+    {
+      "@type": "HowTo",
+      name: "How to use Tene for secret management",
+      step: [
+        {
+          "@type": "HowToStep",
+          name: "Install",
+          text: "Run: curl -sSfL https://tene.sh/install.sh | sh — or download from GitHub Releases (github.com/tomo-kay/tene/releases)",
+        },
+        {
+          "@type": "HowToStep",
+          name: "Initialize",
+          text: "Run tene init to create an encrypted vault and generate context files for Claude, Cursor, Windsurf, Gemini, and Codex.",
+        },
+        {
+          "@type": "HowToStep",
+          name: "Store secrets",
+          text: "Run tene set KEY value to encrypt and store secrets locally.",
+        },
+        {
+          "@type": "HowToStep",
+          name: "Develop with secrets",
+          text: "Run tene run -- your-command to inject secrets as environment variables.",
+        },
+      ],
+    },
+  ],
+};
+
+export function HomeJsonLd() {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(homeJsonLd) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

GSC reported "FAQPage 입력란이 중복" on `/blog/bkit-pdca-for-claude-code` and `/blog/bkit-harness-engineering-vibe-coding` (4 affected items, first detected 26.4.24). Root cause: `layout.tsx` emitted a site-wide FAQPage on every page; per-article and per-comparison FAQPage emissions then collided with it.

## Fix

- Extract FAQPage + HowTo from `layout.tsx` `@graph` → new `<HomeJsonLd />` component
- Render `<HomeJsonLd />` only on `/` (`page.tsx`)
- Keep Organization + WebSite + SoftwareApplication in `layout.tsx` (`@id`-keyed site-wide entities, no duplication risk)
- No change to /vs visible FAQ content or comparison-data FAQPage schema

## Post-build verification

| Page type | FAQPage count | Notes |
|---|:---:|---|
| `/` | 1 | HomeJsonLd general Q&A |
| `/blog/{slug}` | 1 | article frontmatter (was 2) |
| `/vs/{slug}` | 1 | comparison data, 4 Qs each (was 2) |
| `/blog`, `/vs` index, `/privacy` | 0 | meaningless emit removed |

All 5 `/vs/{slug}` pages cross-checked: visible `<dt>` count == FAQPage `mainEntity` count == 4 (1:1 match preserved).

## GSC follow-up (manual after merge)

1. After Vercel deploy: GSC > 잦은 문의 사항 > FAQPage 중복 > "수정 결과 확인" 버튼 클릭
2. URL inspector로 4개 영향 URL 색인 재요청

## Test plan

- [x] `npx next build` clean, all SSG paths emitted
- [x] `/`, `/blog/{slug}`, `/vs/{slug}`, `/blog` index, `/vs` index FAQPage counts verified by grep
- [x] Visible FAQ ↔ JSON-LD FAQPage 1:1 across 5 /vs pages
- [ ] Vercel preview deploy → schema rich-results test
- [ ] Post-merge: GSC FAQPage 중복 보고서 0 confirmation (within 7 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)