### PR TITLE
fix(seo): remove RSS feed entry from sitemap.xml

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -4,8 +4,14 @@ import { getAllCategories, getAllPosts, getAllTags } from "@/lib/blog";
 
 // Next.js generates /sitemap.xml from this file at build time (force-static
 // route). Includes the home page, the /vs index, every /vs/{slug} page, and
-// the /blog + /blog/{slug} + /blog/tag/{tag} + /blog/category/{cat} +
-// /blog/rss.xml. Submit to Google Search Console via "Add sitemap".
+// the /blog + /blog/{slug} + /blog/tag/{tag} + /blog/category/{cat}.
+//
+// /blog/rss.xml is intentionally NOT in this sitemap — it's an RSS feed
+// (XML), not an HTML page. Google flagged it as "크롤링됨 - 색인 안 됨"
+// (crawled but not indexed) when it was here. RSS discovery is handled
+// separately via the `Sitemap:` directive in robots.txt and the
+// <link rel="alternate" type="application/rss+xml"> in the root layout.
+// Submit /sitemap.xml to Google Search Console via "Add sitemap".
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://tene.sh";
   const lastModified = new Date().toISOString();
@@ -68,12 +74,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified,
       changeFrequency: "weekly",
       priority: 0.9,
-    },
-    {
-      url: `${base}/blog/rss.xml`,
-      lastModified,
-      changeFrequency: "weekly",
-      priority: 0.6,
     },
     ...blogPostUrls,
     ...blogCategoryUrls,


### PR DESCRIPTION
## Summary

Google flagged `/blog/rss.xml` as "크롤링됨 - 색인 안 됨" (crawled but not indexed) — likely contributing to the 2 such items in the GSC indexing report. RSS is XML, not HTML — sitemap.xml is the wrong place to advertise it.

## What changed

- Remove `/blog/rss.xml` entry from `apps/web/src/app/sitemap.ts`
- Update file-level comment

## Discovery for the RSS feed remains intact (3 paths)

1. `robots.txt` — `Sitemap: https://tene.sh/blog/rss.xml` directive
2. Root layout — `<link rel="alternate" type="application/rss+xml" href="/blog/rss.xml">` emitted on every page (added in PR #81)
3. Direct fetch at `https://tene.sh/blog/rss.xml`

## Build verification

- Sitemap entries: 45 → 44
- `grep "rss.xml" sitemap.xml` = 0
- `npx next build` clean

## GSC follow-up

After merge + Vercel deploy:
- The "크롤링됨 - 색인 안 됨" 2개 카운트 점진적 감소 예상 (Google 재크롤 사이클)
- canonical-redirect 충돌도 동시에 해소됨 (Vercel `tene.sh` primary 변경 — 코드 변경 없음, 도메인 설정만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)