### PR TITLE
feat(landing): CTA below comparison table → /vs

### DIFF
--- a/apps/web/src/components/comparison.tsx
+++ b/apps/web/src/components/comparison.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { comparisonRows, comparisonPricing } from "@/data/comparison";
 
 // Design Ref: §4.6 — Comparison table with data import, "Secrets hidden from AI" first
@@ -71,6 +72,16 @@ export function Comparison() {
               </tr>
             </tbody>
           </table>
+        </div>
+
+        <div className="mt-10 flex justify-center">
+          <Link
+            href="/vs"
+            className="group inline-flex items-center gap-2 text-sm font-medium text-accent transition-colors hover:text-accent/80 sm:text-base"
+          >
+            See in-depth comparisons against every secret manager
+            <span aria-hidden className="transition-transform group-hover:translate-x-1">→</span>
+          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Adds a text link below the home comparison table directing users to `/vs` for the in-depth per-competitor breakdowns
- Single accent-colored link with arrow, group hover slides arrow +1
- Responsive: text-sm on mobile, text-base on sm+
- No new dependencies, single-file edit (`apps/web/src/components/comparison.tsx`)

## Test plan

- [x] `next build` — 69/69 SSG generates, no errors
- [x] No new lint errors in modified file
- [x] Chrome QA desktop (1920) — CTA below table, accent color, no horizontal scroll, click navigates to /vs (h1 "tene vs everything else", 5 cards)
- [x] Chrome QA mobile (390) — CTA inside viewport, text-sm, no horizontal scroll
- [x] No console errors on / or /vs

🤖 Generated with [Claude Code](https://claude.com/claude-code)