### PR TITLE
fix(seo): emit ISO 8601 datetime with timezone for Schema.org / OG (staging → main)

### DIFF
--- a/apps/web/scripts/verify-blog-indexability.mjs
+++ b/apps/web/scripts/verify-blog-indexability.mjs
@@ -10,6 +10,10 @@
 //      → 404 in production, missing from sitemap
 //   4. Frontmatter missing required field
 //      → already throws at loadPost(), but we re-assert here for clarity
+//   5. Schema.org / OG datetime regression (added 2026-05-02 after Rich
+//      Results Test rejected date-only `datePublished` / `dateModified`)
+//      → catches the case where a future emission site forgets the
+//        toIsoDateTime() helper and ships date-only strings
 //
 // Runs as `npm run verify:blog` and as a postbuild step.
 // Exits non-zero on any violation.
@@ -89,6 +93,82 @@ for (const file of files) {
       `${relPath(filePath)}: draft: true → will be excluded from RSS + sitemap`,
     );
   }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Datetime regression guard — runs only if Next.js has produced its build
+// output (.next/server/app). Skipped during `npm run verify:blog` outside
+// of postbuild (where there's nothing to grep yet).
+// ──────────────────────────────────────────────────────────────────────
+const buildDir = path.resolve(__dirname, "..", ".next", "server", "app");
+
+// ISO 8601 datetime with timezone (Z or ±HH:MM). What Schema.org / OG want.
+// Examples that PASS: "2026-05-02T00:00:00.000Z", "2026-05-02T00:00:00+09:00"
+// Examples that FAIL: "2026-05-02", "2026-05-02T00:00:00" (no TZ)
+const ISO_DT = /T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})/;
+
+function checkDatetimeFile(htmlPath) {
+  const html = fs.readFileSync(htmlPath, "utf-8");
+  const rel = path.relative(path.resolve(__dirname, ".."), htmlPath);
+  // Schema.org JSON-LD fields
+  for (const field of ["datePublished", "dateModified"]) {
+    const matches = html.match(
+      new RegExp(`"${field}":"([^"]+)"`, "g"),
+    );
+    if (!matches) continue;
+    for (const m of matches) {
+      const v = m.match(/"[^"]+":"([^"]+)"/)[1];
+      if (!ISO_DT.test(v)) {
+        errors.push(
+          `${rel}: Schema.org ${field}='${v}' is not full ISO 8601 datetime ` +
+            `with timezone. Use src/lib/iso-date.ts → toIsoDateTime().`,
+        );
+      }
+    }
+  }
+  // OpenGraph article:*_time meta tags
+  for (const prop of ["article:published_time", "article:modified_time"]) {
+    const matches = html.match(
+      new RegExp(`property="${prop}"[^>]*content="([^"]+)"`, "g"),
+    );
+    if (!matches) continue;
+    for (const m of matches) {
+      const v = m.match(/content="([^"]+)"/)[1];
+      if (!ISO_DT.test(v)) {
+        errors.push(
+          `${rel}: OG ${prop}='${v}' is not full ISO 8601 datetime ` +
+            `with timezone. Wrap with toIsoDateTime() in the page metadata.`,
+        );
+      }
+    }
+  }
+}
+
+function walkHtml(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkHtml(p));
+    else if (e.isFile() && e.name.endsWith(".html")) out.push(p);
+  }
+  return out;
+}
+
+if (fs.existsSync(buildDir)) {
+  const htmlFiles = walkHtml(buildDir);
+  // Only the surfaces that emit datePublished/dateModified or OG article:*_time.
+  const relevant = htmlFiles.filter((p) => {
+    const rel = path.relative(buildDir, p);
+    return (
+      rel.startsWith("blog") ||
+      rel === "cli.html" ||
+      rel.startsWith("vs/") ||
+      rel.startsWith("vs.html")
+    );
+  });
+  for (const p of relevant) checkDatetimeFile(p);
 }
 
 if (warnings.length) {

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
   getPostBySlug,
   getRelatedPosts,
 } from "@/lib/blog";
+import { toIsoDateTime } from "@/lib/iso-date";
 
 export const dynamic = "error";
 
@@ -57,8 +58,10 @@ export async function generateMetadata({
       url: canonical,
       siteName: "Tene",
       type: "article",
-      publishedTime: post.meta.publishedAt,
-      modifiedTime: post.meta.updatedAt ?? post.meta.publishedAt,
+      // OG article:*_time also wants full ISO 8601 datetime — same helper
+      // as Schema.org so both surfaces stay in lockstep.
+      publishedTime: toIsoDateTime(post.meta.publishedAt),
+      modifiedTime: toIsoDateTime(post.meta.updatedAt ?? post.meta.publishedAt),
       authors: [post.meta.author ?? "agent-kay"],
       tags: post.meta.tags,
       // blog-seo-enhancements G3 — Next.js auto-wires og:image from the

--- a/apps/web/src/app/vs/[slug]/page.tsx
+++ b/apps/web/src/app/vs/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
   getComparison,
   getRelatedComparisons,
 } from "@/data/comparisons";
+import { toIsoDateTime } from "@/lib/iso-date";
 
 // Static at build time — no database, no request-time work. Every slug is
 // known ahead of time, so Next.js renders these pages as static HTML with
@@ -51,8 +52,8 @@ export async function generateMetadata({
       url: canonical,
       siteName: "Tene",
       type: "article",
-      publishedTime: data.publishedAt,
-      modifiedTime: data.updatedAt,
+      publishedTime: toIsoDateTime(data.publishedAt),
+      modifiedTime: toIsoDateTime(data.updatedAt),
       images: [
         {
           url: "/og-image.webp",

--- a/apps/web/src/components/blog/post-card.tsx
+++ b/apps/web/src/components/blog/post-card.tsx
@@ -10,12 +10,19 @@ type Props = {
   featured?: boolean;
 };
 
+// en-US fixed format ("May 2, 2026"). The site is English-only
+// (`inLanguage: 'en-US'`) so the visible date stays English regardless of
+// browser locale. `timeZone: "UTC"` pins the rendered calendar day to the
+// publish day; otherwise UTC+13 (Auckland) viewers would see a date one day
+// ahead of the author's intent.
 function formatDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleDateString("en-US", {
+    const anchor = /T\d/.test(iso) ? iso : `${iso}T12:00:00.000Z`;
+    return new Date(anchor).toLocaleDateString("en-US", {
       year: "numeric",
       month: "short",
       day: "numeric",
+      timeZone: "UTC",
     });
   } catch {
     return iso;

--- a/apps/web/src/components/blog/post-hero.tsx
+++ b/apps/web/src/components/blog/post-hero.tsx
@@ -7,12 +7,16 @@ type Props = {
   meta: BlogPostMeta;
 };
 
+// en-US fixed format. See post-card.tsx for the rationale (site is
+// English-only; UTC anchor keeps the calendar day stable across viewers).
 function formatDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleDateString("en-US", {
+    const anchor = /T\d/.test(iso) ? iso : `${iso}T12:00:00.000Z`;
+    return new Date(anchor).toLocaleDateString("en-US", {
       year: "numeric",
       month: "long",
       day: "numeric",
+      timeZone: "UTC",
     });
   } catch {
     return iso;

--- a/apps/web/src/components/seo/article-jsonld.tsx
+++ b/apps/web/src/components/seo/article-jsonld.tsx
@@ -2,6 +2,7 @@
 // single @graph. Adds articleSection (G4) and author.sameAs (G5) alongside
 // the breadcrumb trail (G1).
 import { getCategoryLabel } from "@/lib/tags";
+import { toIsoDateTime } from "@/lib/iso-date";
 import type { BlogPostMeta } from "@/lib/blog";
 
 type Props = {
@@ -18,8 +19,11 @@ export function BlogPostingJsonLd({ meta }: Props) {
         "@type": "BlogPosting",
         headline: meta.title,
         description: meta.description,
-        datePublished: meta.publishedAt,
-        dateModified: meta.updatedAt ?? meta.publishedAt,
+        // Schema.org requires full ISO 8601 datetime with timezone — the
+        // helper anchors date-only frontmatter at UTC midnight (Z). See
+        // src/lib/iso-date.ts for the rationale.
+        datePublished: toIsoDateTime(meta.publishedAt),
+        dateModified: toIsoDateTime(meta.updatedAt ?? meta.publishedAt),
         // G4 — articleSection maps to the post's category (taxonomy change
         // 2026-04-24: previously used first tag; category is now the
         // primary navigation axis and a better Schema.org match).

--- a/apps/web/src/components/seo/blog-index-jsonld.tsx
+++ b/apps/web/src/components/seo/blog-index-jsonld.tsx
@@ -3,6 +3,7 @@
 // this to identify the section as a blog and enumerate articles for citation.
 import type { BlogPostMeta } from "@/lib/blog";
 import { getCategoryLabel, getTagLabel } from "@/lib/tags";
+import { toIsoDateTime } from "@/lib/iso-date";
 
 type Props = {
   posts: BlogPostMeta[];
@@ -67,8 +68,8 @@ export function BlogIndexJsonLd({ posts, tag, category }: Props) {
           headline: p.title,
           description: p.description,
           url: `https://tene.sh/blog/${p.slug}`,
-          datePublished: p.publishedAt,
-          dateModified: p.updatedAt ?? p.publishedAt,
+          datePublished: toIsoDateTime(p.publishedAt),
+          dateModified: toIsoDateTime(p.updatedAt ?? p.publishedAt),
           articleSection: getCategoryLabel(p.category),
           keywords: p.tags.join(", "),
           author: {

--- a/apps/web/src/components/seo/cli-jsonld.tsx
+++ b/apps/web/src/components/seo/cli-jsonld.tsx
@@ -74,7 +74,11 @@ export function CliJsonLd({ dateModified }: Props) {
         headline: "tene CLI Reference",
         description:
           "Canonical reference for every tene command, flag, exit code, and JSON schema.",
-        datePublished: "2026-04-22",
+        // Full ISO 8601 datetime with timezone (UTC) — Google Rich Results
+        // Test rejects date-only values. `dateModified` is already
+        // `mtime.toISOString()` which is full ISO; this literal mirrors
+        // that format for `datePublished`.
+        datePublished: "2026-04-22T00:00:00.000Z",
         dateModified,
         author: {
           "@type": "Person",

--- a/apps/web/src/lib/iso-date.ts
+++ b/apps/web/src/lib/iso-date.ts
@@ -1,0 +1,26 @@
+// Convert frontmatter calendar dates ("YYYY-MM-DD") to the full ISO 8601
+// datetime format required by Schema.org datePublished / dateModified and the
+// OpenGraph article:published_time / article:modified_time meta tags.
+//
+// Why this exists: Google Rich Results Test rejects date-only values with
+//   - 'datePublished'의 datetime 값이 잘못됨
+//   - datetime 속성에 시간대가 누락됨
+// (see https://search.google.com/test/rich-results)
+//
+// Why UTC (Z), not a fixed local offset:
+//   tene.sh is a globally-targeted blog. Anchoring at the operator's local
+//   timezone (e.g. KST +09:00) bakes a bias into machine-readable surfaces
+//   that have no reason to favour any region. UTC is what Google's own
+//   documentation samples use, what `sitemap.ts` already emits, and what
+//   every search engine normalises against. Pick one neutral anchor and
+//   keep it consistent across every emission boundary.
+//
+// Authors keep writing date-only frontmatter ("2026-05-02") — that stays
+// human-readable and locale-agnostic. The conversion to a full datetime
+// happens at the emission boundary (this helper) so no future post can
+// accidentally ship without a timezone.
+export function toIsoDateTime(value: string): string {
+  // Already a full datetime (has 'T' followed by digits)? leave alone.
+  if (/T\d/.test(value)) return value;
+  return `${value}T00:00:00.000Z`;
+}


### PR DESCRIPTION
## Summary

Promotes #104 from staging to main.

- Google Rich Results Test rejected `datePublished` / `dateModified` (date-only, missing timezone). Same issue on OG `article:*_time`.
- Root-cause helper `toIsoDateTime()` at the emission boundary anchors date-only frontmatter at UTC midnight (Z). Applied to all 5 emission sites.
- Postbuild verifier extended to fail the build on any future date-only regression.
- Visible blog dates stay en-US fixed with `timeZone: 'UTC'` for cross-viewer calendar-day stability.

## Why UTC, not KST

tene.sh is globally targeted. UTC is what `sitemap.ts` already emits and what every search engine normalises against.

## Verified on staging Vercel preview

- Schema.org / OG datetime: `2026-05-02T00:00:00.000Z` across all blog/cli/vs surfaces
- Visible date: "May 2, 2026" (en-US) regardless of browser locale
- Postbuild verifier negative-test: rejects date-only regression with exit 1
- Chrome MCP sweep: 0 console errors, no horizontal scroll on any page

## Test plan

- [x] PR #104 CI green (lint, test, vercel, vercel preview comments)
- [x] Squash-merged into staging
- [ ] Re-run https://search.google.com/test/rich-results?url=https://tene.sh/blog/make-ai-recommend-your-app after main deploys → expect both datetime warnings cleared