### PR TITLE
fix(seo): FAQPage duplicate fix + new philosophy blog post

### DIFF
--- a/apps/web/content/blog/9-day-msa-with-claude-code.mdx
+++ b/apps/web/content/blog/9-day-msa-with-claude-code.mdx
@@ -1,23 +1,52 @@
 ---
 slug: 9-day-msa-with-claude-code
-title: "9 days to ship bkamp.ai with Claude Code — and what became bkit"
-description: "One founder plus Claude Code shipped 11 microservices to production in 9 days. The playbook is now bkit, a CC plugin. A case study and method."
-publishedAt: "2026-04-29"
-updatedAt: "2026-04-29"
+title: 9 days to ship bkamp.ai with Claude Code — and what became bkit
+description: >-
+  One founder plus Claude Code shipped 11 microservices to production in 9 days.
+  The playbook is now bkit, a CC plugin. A case study and method.
+publishedAt: '2026-04-29'
+updatedAt: '2026-04-29'
 category: vibe-coding
-tags: ["bkit", "claude-code", "harness-engineering", "deep-dive"]
-author: "agent-kay"
-thumbnail: "/blog/bkamp-knowhow-to-bkit-plugin/bkamp-home.webp"
-canonicalUrl: "https://tene.sh/blog/9-day-msa-with-claude-code"
+tags:
+  - bkit
+  - claude-code
+  - harness-engineering
+  - deep-dive
+author: agent-kay
+thumbnail: /blog/bkamp-knowhow-to-bkit-plugin/bkamp-home.webp
+canonicalUrl: 'https://tene.sh/blog/9-day-msa-with-claude-code'
 faqs:
-  - question: "Could anyone reproduce the 9-day timeline?"
-    answer: "Not by typing faster. The compression came from work done before Day 1: a 159-line meta-rule file, a numbered design archive, and a habit of writing the spec before asking the model to scaffold. Without that scaffolding, even a faster model just produces 70% slop faster. With it, scaffolding eleven microservices in a day is a translation problem, not an authoring one."
-  - question: "Why turn a personal workflow (bkamp) into a public plugin (bkit)?"
-    answer: "Because the workflow that made bkamp possible was not in the code — it was in the conventions, the document numbering, the daily PDCA cadence, and the checkpoint-then-rewrite habit. None of that travels with a Git repo. bkit packages it as Claude Code Skills, Agents, Hooks, an MCP server, and a state machine, so the next person doesn't have to re-derive it from scratch."
-  - question: "Does bkit only work with Claude Code?"
-    answer: "Today, yes — the harness is built on CC's plugin surface (Skills, Agents, Hooks, MCP). The patterns it encodes — Plan/Design/Do/Check/Act, Match Rate gates, trust-graduated automation, port/adapter purity — are model-agnostic. A Codex- or Cursor-shaped fork would be feasible but does not exist yet."
-  - question: "Is 'vibe coding' just hype?"
-    answer: "Read literally — typing prompts and accepting whatever comes back — yes, it is hype, and it produces brittle code. Read as a discipline — context engineering, design-first, AI-evaluator loops, automatic checkpoints — it is just engineering with a new tool in the loop. The 9-day bkamp launch is empirical evidence that the disciplined version works. The seven patterns below are the rules of the disciplined version."
+  - question: Could anyone reproduce the 9-day timeline?
+    answer: >-
+      Not by typing faster. The compression came from work done before Day 1: a
+      159-line meta-rule file, a numbered design archive, and a habit of writing
+      the spec before asking the model to scaffold. Without that scaffolding,
+      even a faster model just produces 70% slop faster. With it, scaffolding
+      eleven microservices in a day is a translation problem, not an authoring
+      one.
+  - question: Why turn a personal workflow (bkamp) into a public plugin (bkit)?
+    answer: >-
+      Because the workflow that made bkamp possible was not in the code — it was
+      in the conventions, the document numbering, the daily PDCA cadence, and
+      the checkpoint-then-rewrite habit. None of that travels with a Git repo.
+      bkit packages it as Claude Code Skills, Agents, Hooks, an MCP server, and
+      a state machine, so the next person doesn't have to re-derive it from
+      scratch.
+  - question: Does bkit only work with Claude Code?
+    answer: >-
+      Today, yes — the harness is built on CC's plugin surface (Skills, Agents,
+      Hooks, MCP). The patterns it encodes — Plan/Design/Do/Check/Act, Match
+      Rate gates, trust-graduated automation, port/adapter purity — are
+      model-agnostic. A Codex- or Cursor-shaped fork would be feasible but does
+      not exist yet.
+  - question: Is 'vibe coding' just hype?
+    answer: >-
+      Read literally — typing prompts and accepting whatever comes back — yes,
+      it is hype, and it produces brittle code. Read as a discipline — context
+      engineering, design-first, AI-evaluator loops, automatic checkpoints — it
+      is just engineering with a new tool in the loop. The 9-day bkamp launch is
+      empirical evidence that the disciplined version works. The seven patterns
+      below are the rules of the disciplined version.
 ---
 
 In December 2025 I shipped a content platform called bkamp.ai. Eleven
@@ -420,6 +449,25 @@ And the platform that proved the method is live at
 **Terraform** — A tool that builds cloud infrastructure (servers, networks,
   databases) from text files. Edit the files, run the tool, the
   cloud changes to match.
+
+## FAQ
+
+**Could anyone reproduce the 9-day timeline?**
+
+Not by typing faster. The compression came from work done before Day 1: a 159-line meta-rule file, a numbered design archive, and a habit of writing the spec before asking the model to scaffold. Without that scaffolding, even a faster model just produces 70% slop faster. With it, scaffolding eleven microservices in a day is a translation problem, not an authoring one.
+
+**Why turn a personal workflow (bkamp) into a public plugin (bkit)?**
+
+Because the workflow that made bkamp possible was not in the code — it was in the conventions, the document numbering, the daily PDCA cadence, and the checkpoint-then-rewrite habit. None of that travels with a Git repo. bkit packages it as Claude Code Skills, Agents, Hooks, an MCP server, and a state machine, so the next person doesn't have to re-derive it from scratch.
+
+**Does bkit only work with Claude Code?**
+
+Today, yes — the harness is built on CC's plugin surface (Skills, Agents, Hooks, MCP). The patterns it encodes — Plan/Design/Do/Check/Act, Match Rate gates, trust-graduated automation, port/adapter purity — are model-agnostic. A Codex- or Cursor-shaped fork would be feasible but does not exist yet.
+
+**Is 'vibe coding' just hype?**
+
+Read literally — typing prompts and accepting whatever comes back — yes, it is hype, and it produces brittle code. Read as a discipline — context engineering, design-first, AI-evaluator loops, automatic checkpoints — it is just engineering with a new tool in the loop. The 9-day bkamp launch is empirical evidence that the disciplined version works. The seven patterns below are the rules of the disciplined version.
+
 
 Related reading:
 - [Harness engineering for vibe coding](/blog/bkit-harness-engineering-vibe-coding)

--- a/apps/web/content/blog/ai-agents-and-human-responsibility.mdx
+++ b/apps/web/content/blog/ai-agents-and-human-responsibility.mdx
@@ -1,21 +1,48 @@
 ---
 slug: ai-agents-and-human-responsibility
-title: "AI agents, human responsibility, and the harness in between"
-description: "Chatbots got good. Agents did not — not because the models aren't smart, but because the system around them isn't. Roles, responsibility, and why PDCA + L0–L4 control beats another model upgrade."
-publishedAt: "2026-04-24"
-updatedAt: "2026-04-24"
+title: 'AI agents, human responsibility, and the harness in between'
+description: >-
+  Chatbots got good. Agents did not — not because the models aren't smart, but
+  because the system around them isn't. Roles, responsibility, and why PDCA +
+  L0–L4 control beats another model upgrade.
+publishedAt: '2026-04-24'
+updatedAt: '2026-04-24'
 category: philosophy
-tags: ["bkit", "workflow", "harness-engineering", "founder-story"]
-author: "agent-kay"
-cover: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/ai-agents-and-human-responsibility"
+tags:
+  - bkit
+  - workflow
+  - harness-engineering
+  - founder-story
+author: agent-kay
+cover: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/ai-agents-and-human-responsibility'
 faqs:
-  - question: "If 90% of Anthropic's code is AI-written, why are they still hiring engineers?"
-    answer: "Because execution and accountability are separate jobs. AI handles the coding, testing, and debugging; humans decide what to build, why, for whom, and sign off when it's done. As AI takes over more execution, human time shifts from typing to judging — and judging is the part that carries legal, product, and customer-facing responsibility. The job title survives; the daily activity changes."
-  - question: "Is 'fully autonomous AI agent' a realistic goal for my product?"
-    answer: "Not in 2026. Every AI team shipping at scale — Anthropic, Cursor, GitHub — runs with graduated automation: routine steps auto-approved, high-stakes decisions gated through a human. The gain is not 'zero humans' but 'humans only at the decisions that actually need a human.' Binary thinking (manual vs fully auto) is the most common failure mode."
-  - question: "How does bkit's L0–L4 automation level differ from a config flag?"
-    answer: "A config flag is static — you turn it on, it stays on. L0–L4 is earned. Escalating from L2 to L3 requires a Trust Score derived from your project's actual track record (match rate, destructive-op count, interrupt frequency). The system graduates trust per project, not per user or per model, and a cooldown prevents a lucky streak from unlocking autonomy prematurely. It's closer to a pilot's flight-hour certification than a toggle."
+  - question: >-
+      If 90% of Anthropic's code is AI-written, why are they still hiring
+      engineers?
+    answer: >-
+      Because execution and accountability are separate jobs. AI handles the
+      coding, testing, and debugging; humans decide what to build, why, for
+      whom, and sign off when it's done. As AI takes over more execution, human
+      time shifts from typing to judging — and judging is the part that carries
+      legal, product, and customer-facing responsibility. The job title
+      survives; the daily activity changes.
+  - question: Is 'fully autonomous AI agent' a realistic goal for my product?
+    answer: >-
+      Not in 2026. Every AI team shipping at scale — Anthropic, Cursor, GitHub —
+      runs with graduated automation: routine steps auto-approved, high-stakes
+      decisions gated through a human. The gain is not 'zero humans' but 'humans
+      only at the decisions that actually need a human.' Binary thinking (manual
+      vs fully auto) is the most common failure mode.
+  - question: How does bkit's L0–L4 automation level differ from a config flag?
+    answer: >-
+      A config flag is static — you turn it on, it stays on. L0–L4 is earned.
+      Escalating from L2 to L3 requires a Trust Score derived from your
+      project's actual track record (match rate, destructive-op count, interrupt
+      frequency). The system graduates trust per project, not per user or per
+      model, and a cooldown prevents a lucky streak from unlocking autonomy
+      prematurely. It's closer to a pilot's flight-hour certification than a
+      toggle.
 ---
 
 ## Chatbots are solved. Agents are not.
@@ -341,6 +368,21 @@ difference is the loop.
 
 **Match rate** — A measured number (target: 90%) for "how faithful is the build
   to the design doc?" Replaces vibes-based code review.
+
+## FAQ
+
+**If 90% of Anthropic's code is AI-written, why are they still hiring engineers?**
+
+Because execution and accountability are separate jobs. AI handles the coding, testing, and debugging; humans decide what to build, why, for whom, and sign off when it's done. As AI takes over more execution, human time shifts from typing to judging — and judging is the part that carries legal, product, and customer-facing responsibility. The job title survives; the daily activity changes.
+
+**Is 'fully autonomous AI agent' a realistic goal for my product?**
+
+Not in 2026. Every AI team shipping at scale — Anthropic, Cursor, GitHub — runs with graduated automation: routine steps auto-approved, high-stakes decisions gated through a human. The gain is not 'zero humans' but 'humans only at the decisions that actually need a human.' Binary thinking (manual vs fully auto) is the most common failure mode.
+
+**How does bkit's L0–L4 automation level differ from a config flag?**
+
+A config flag is static — you turn it on, it stays on. L0–L4 is earned. Escalating from L2 to L3 requires a Trust Score derived from your project's actual track record (match rate, destructive-op count, interrupt frequency). The system graduates trust per project, not per user or per model, and a cooldown prevents a lucky streak from unlocking autonomy prematurely. It's closer to a pilot's flight-hour certification than a toggle.
+
 
 Related reading:
 - [bkit + harness engineering: workflow beats model choice](/blog/bkit-harness-engineering-vibe-coding)

--- a/apps/web/content/blog/ai-reads-env.mdx
+++ b/apps/web/content/blog/ai-reads-env.mdx
@@ -1,22 +1,38 @@
 ---
 slug: ai-reads-env
-title: "Your .env is not a secret. AI can read it."
-description: "Plaintext .env files are a liability in the AI coding era. Here is why the AI-agent threat model changes the math, and what to replace .env with."
-publishedAt: "2026-04-23"
-updatedAt: "2026-04-23"
+title: Your .env is not a secret. AI can read it.
+description: >-
+  Plaintext .env files are a liability in the AI coding era. Here is why the
+  AI-agent threat model changes the math, and what to replace .env with.
+publishedAt: '2026-04-23'
+updatedAt: '2026-04-23'
 category: vibe-coding
-tags: ["security", "devsecops", "tene"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/demo/the-full-story-demo.gif"
-canonicalUrl: "https://tene.sh/blog/ai-reads-env"
+tags:
+  - security
+  - devsecops
+  - tene
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /demo/the-full-story-demo.gif
+canonicalUrl: 'https://tene.sh/blog/ai-reads-env'
 faqs:
-  - question: "Does .gitignore protect my .env from AI agents?"
-    answer: ".gitignore prevents Git from committing the file. It does nothing about the AI agent running on your machine — the agent reads the file from disk as part of the project context before any git boundary."
-  - question: "Which AI agents read .env?"
-    answer: "Every major coding assistant indexes project files as part of its context. Claude Code, Cursor, Windsurf, Gemini Code Assist, GitHub Copilot Chat, and Codex all read local files including .env unless explicitly excluded via an ignore file."
-  - question: "What should replace .env?"
-    answer: "Encrypt secrets at rest and inject them at runtime as environment variables. tene is one implementation — XChaCha20-Poly1305 vault plus 'tene run --' subshell. Your application code keeps reading process.env.* unchanged."
+  - question: Does .gitignore protect my .env from AI agents?
+    answer: >-
+      .gitignore prevents Git from committing the file. It does nothing about
+      the AI agent running on your machine — the agent reads the file from disk
+      as part of the project context before any git boundary.
+  - question: Which AI agents read .env?
+    answer: >-
+      Every major coding assistant indexes project files as part of its context.
+      Claude Code, Cursor, Windsurf, Gemini Code Assist, GitHub Copilot Chat,
+      and Codex all read local files including .env unless explicitly excluded
+      via an ignore file.
+  - question: What should replace .env?
+    answer: >-
+      Encrypt secrets at rest and inject them at runtime as environment
+      variables. tene is one implementation — XChaCha20-Poly1305 vault plus
+      'tene run --' subshell. Your application code keeps reading process.env.*
+      unchanged.
 ---
 
 ## The AI-agent threat model changes the math
@@ -145,3 +161,18 @@ roadmap includes a reference server.
 
 tene is one option. You can build your own. What matters is that you
 stop trusting `.env` with values an AI coding agent will read.
+
+## FAQ
+
+**Does .gitignore protect my .env from AI agents?**
+
+.gitignore prevents Git from committing the file. It does nothing about the AI agent running on your machine — the agent reads the file from disk as part of the project context before any git boundary.
+
+**Which AI agents read .env?**
+
+Every major coding assistant indexes project files as part of its context. Claude Code, Cursor, Windsurf, Gemini Code Assist, GitHub Copilot Chat, and Codex all read local files including .env unless explicitly excluded via an ignore file.
+
+**What should replace .env?**
+
+Encrypt secrets at rest and inject them at runtime as environment variables. tene is one implementation — XChaCha20-Poly1305 vault plus 'tene run --' subshell. Your application code keeps reading process.env.* unchanged.
+

--- a/apps/web/content/blog/ax-redesign-not-ai-tools.mdx
+++ b/apps/web/content/blog/ax-redesign-not-ai-tools.mdx
@@ -1,24 +1,47 @@
 ---
 slug: ax-redesign-not-ai-tools
-title: "AX is not AI tool adoption — it is organizational redesign"
-description: "The 5% capturing AI value at scale redesigned roles, workflows, governance, data, and KPIs before picking a model. The 95% in pilot purgatory did not."
-publishedAt: "2026-04-28"
-updatedAt: "2026-04-28"
+title: AX is not AI tool adoption — it is organizational redesign
+description: >-
+  The 5% capturing AI value at scale redesigned roles, workflows, governance,
+  data, and KPIs before picking a model. The 95% in pilot purgatory did not.
+publishedAt: '2026-04-28'
+updatedAt: '2026-04-28'
 category: philosophy
-tags: ["workflow", "harness-engineering", "founder-story", "deep-dive"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/blog/ax-is-not-ai-tool-adoption/ax-important-org-cultures.webp"
-canonicalUrl: "https://tene.sh/blog/ax-redesign-not-ai-tools"
+tags:
+  - workflow
+  - harness-engineering
+  - founder-story
+  - deep-dive
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /blog/ax-is-not-ai-tool-adoption/ax-important-org-cultures.webp
+canonicalUrl: 'https://tene.sh/blog/ax-redesign-not-ai-tools'
 faqs:
-  - question: "Is AX just rebranded digital transformation?"
-    answer: "Digital transformation moved paper-based processes online. AX redistributes decision rights between humans and software that can decide on its own. DT produced systems-of-record; AX produces operating models. The deliverable is different — and so is the failure mode."
-  - question: "What is the smallest unit of 'AI-native' that is still meaningful?"
-    answer: "A single workflow where the human role has shifted from execution to intent-and-approval and the AI role is execution-and-verification, with both halves logged and reviewable. Not a department, not a company — one workflow at a time. Stack them."
-  - question: "How long does AX actually take?"
-    answer: "The McKinsey 'AI high performers' who attribute 5%+ of EBIT to AI typically spent 2–3 years on workflow redesign, not 2–3 quarters on pilots. The 95% stuck in pilot purgatory have often been there for over 18 months. Speed comes from compounding decisions, not from buying faster models."
-  - question: "Does this require firing people?"
-    answer: "The data points the other way: high performers are roughly 2× more likely to invest in ambitious upskilling. Roles shift rapidly; headcount shifts lag and depend on growth, not on AI itself. Organizations that fire first usually lose institutional context faster than they gain AI capability."
+  - question: Is AX just rebranded digital transformation?
+    answer: >-
+      Digital transformation moved paper-based processes online. AX
+      redistributes decision rights between humans and software that can decide
+      on its own. DT produced systems-of-record; AX produces operating models.
+      The deliverable is different — and so is the failure mode.
+  - question: What is the smallest unit of 'AI-native' that is still meaningful?
+    answer: >-
+      A single workflow where the human role has shifted from execution to
+      intent-and-approval and the AI role is execution-and-verification, with
+      both halves logged and reviewable. Not a department, not a company — one
+      workflow at a time. Stack them.
+  - question: How long does AX actually take?
+    answer: >-
+      The McKinsey 'AI high performers' who attribute 5%+ of EBIT to AI
+      typically spent 2–3 years on workflow redesign, not 2–3 quarters on
+      pilots. The 95% stuck in pilot purgatory have often been there for over 18
+      months. Speed comes from compounding decisions, not from buying faster
+      models.
+  - question: Does this require firing people?
+    answer: >-
+      The data points the other way: high performers are roughly 2× more likely
+      to invest in ambitious upskilling. Roles shift rapidly; headcount shifts
+      lag and depend on growth, not on AI itself. Organizations that fire first
+      usually lose institutional context faster than they gain AI capability.
 ---
 
 ## The wrong question every executive is asking
@@ -178,6 +201,25 @@ That's the experiential proof. It's also the only proof that scales. AI adoption
 **EBIT** — Earnings Before Interest and Taxes. The McKinsey "AI high performer" tag means a company credits more than 5% of EBIT to AI.
 
 **EU AI Act** — The European Union's AI law. Becomes fully enforceable on August 2, 2026. Forces organizations to answer governance questions for every AI-touched workflow.
+
+## FAQ
+
+**Is AX just rebranded digital transformation?**
+
+Digital transformation moved paper-based processes online. AX redistributes decision rights between humans and software that can decide on its own. DT produced systems-of-record; AX produces operating models. The deliverable is different — and so is the failure mode.
+
+**What is the smallest unit of 'AI-native' that is still meaningful?**
+
+A single workflow where the human role has shifted from execution to intent-and-approval and the AI role is execution-and-verification, with both halves logged and reviewable. Not a department, not a company — one workflow at a time. Stack them.
+
+**How long does AX actually take?**
+
+The McKinsey 'AI high performers' who attribute 5%+ of EBIT to AI typically spent 2–3 years on workflow redesign, not 2–3 quarters on pilots. The 95% stuck in pilot purgatory have often been there for over 18 months. Speed comes from compounding decisions, not from buying faster models.
+
+**Does this require firing people?**
+
+The data points the other way: high performers are roughly 2× more likely to invest in ambitious upskilling. Roles shift rapidly; headcount shifts lag and depend on growth, not on AI itself. Organizations that fire first usually lose institutional context faster than they gain AI capability.
+
 
 Related reading:
 - [AI agents, human responsibility, and the harness in between](/blog/ai-agents-and-human-responsibility)

--- a/apps/web/content/blog/bkit-harness-engineering-vibe-coding.mdx
+++ b/apps/web/content/blog/bkit-harness-engineering-vibe-coding.mdx
@@ -1,22 +1,41 @@
 ---
 slug: bkit-harness-engineering-vibe-coding
-title: "bkit + harness engineering: workflow beats model choice"
-description: "Why the workflow around Claude Code matters more than picking a bigger model. Harness engineering, bkit's PDCA, and L0–L4 trust-graduated automation."
-publishedAt: "2026-04-23"
-updatedAt: "2026-04-23"
+title: 'bkit + harness engineering: workflow beats model choice'
+description: >-
+  Why the workflow around Claude Code matters more than picking a bigger model.
+  Harness engineering, bkit's PDCA, and L0–L4 trust-graduated automation.
+publishedAt: '2026-04-23'
+updatedAt: '2026-04-23'
 category: vibe-coding
-tags: ["bkit", "harness-engineering", "workflow"]
-author: "agent-kay"
-cover: "/blog/bkit-harness-engineering-vibe-coding/bkit-og.png"
-thumbnail: "/blog/bkit-harness-engineering-vibe-coding/bkit-og.png"
-canonicalUrl: "https://tene.sh/blog/bkit-harness-engineering-vibe-coding"
+tags:
+  - bkit
+  - harness-engineering
+  - workflow
+author: agent-kay
+cover: /blog/bkit-harness-engineering-vibe-coding/bkit-og.png
+thumbnail: /blog/bkit-harness-engineering-vibe-coding/bkit-og.png
+canonicalUrl: 'https://tene.sh/blog/bkit-harness-engineering-vibe-coding'
 faqs:
-  - question: "Does the model choice not matter at all?"
-    answer: "It matters, but second-order. With a thin workflow around it, a better model just repeats the same mistakes faster. The real power is in the loop: what context the model sees, how its output is evaluated, and what happens when it's wrong. bkit's gap-detector and auto-iterate close failure modes that a bigger model alone does not."
-  - question: "Can I get the same result from plain Claude Code, without bkit?"
-    answer: "Yes, if you are willing to hand-roll the workflow every session: write plan and design docs, review iterations, set your own guardrails. bkit encodes that discipline as a state machine and a set of agents so you do not have to rebuild it per project. It is the difference between a framework and a convention."
-  - question: "Is 'harness engineering' an established term?"
-    answer: "It became common in 2025 as multi-agent systems matured. The idea: LLM inference is a leaf, and the surrounding engineering — context curation, tool orchestration, state, guardrails, retry loops — is what determines real-world reliability. Prompt engineering is one piece inside a harness."
+  - question: Does the model choice not matter at all?
+    answer: >-
+      It matters, but second-order. With a thin workflow around it, a better
+      model just repeats the same mistakes faster. The real power is in the
+      loop: what context the model sees, how its output is evaluated, and what
+      happens when it's wrong. bkit's gap-detector and auto-iterate close
+      failure modes that a bigger model alone does not.
+  - question: 'Can I get the same result from plain Claude Code, without bkit?'
+    answer: >-
+      Yes, if you are willing to hand-roll the workflow every session: write
+      plan and design docs, review iterations, set your own guardrails. bkit
+      encodes that discipline as a state machine and a set of agents so you do
+      not have to rebuild it per project. It is the difference between a
+      framework and a convention.
+  - question: Is 'harness engineering' an established term?
+    answer: >-
+      It became common in 2025 as multi-agent systems matured. The idea: LLM
+      inference is a leaf, and the surrounding engineering — context curation,
+      tool orchestration, state, guardrails, retry loops — is what determines
+      real-world reliability. Prompt engineering is one piece inside a harness.
 ---
 
 ## The model churn trap
@@ -191,6 +210,21 @@ instead of evaporating.
 
 **PDCA** — Plan, Do, Check, Act. A four-step cycle. bkit turns it into a
   state machine with clear gates between phases.
+
+## FAQ
+
+**Does the model choice not matter at all?**
+
+It matters, but second-order. With a thin workflow around it, a better model just repeats the same mistakes faster. The real power is in the loop: what context the model sees, how its output is evaluated, and what happens when it's wrong. bkit's gap-detector and auto-iterate close failure modes that a bigger model alone does not.
+
+**Can I get the same result from plain Claude Code, without bkit?**
+
+Yes, if you are willing to hand-roll the workflow every session: write plan and design docs, review iterations, set your own guardrails. bkit encodes that discipline as a state machine and a set of agents so you do not have to rebuild it per project. It is the difference between a framework and a convention.
+
+**Is 'harness engineering' an established term?**
+
+It became common in 2025 as multi-agent systems matured. The idea: LLM inference is a leaf, and the surrounding engineering — context curation, tool orchestration, state, guardrails, retry loops — is what determines real-world reliability. Prompt engineering is one piece inside a harness.
+
 
 Related reading:
 - [bkit on GitHub (popup-studio-ai/bkit-claude-code)](https://github.com/popup-studio-ai/bkit-claude-code)

--- a/apps/web/content/blog/bkit-pdca-for-claude-code.mdx
+++ b/apps/web/content/blog/bkit-pdca-for-claude-code.mdx
@@ -1,22 +1,39 @@
 ---
 slug: bkit-pdca-for-claude-code
-title: "bkit: PDCA methodology for Claude Code"
-description: "bkit encodes PDCA methodology into Claude Code: Skills, Agents, Hooks, MCP, and a state machine with quality gates from plan to report."
-publishedAt: "2026-04-23"
-updatedAt: "2026-04-23"
+title: 'bkit: PDCA methodology for Claude Code'
+description: >-
+  bkit encodes PDCA methodology into Claude Code: Skills, Agents, Hooks, MCP,
+  and a state machine with quality gates from plan to report.
+publishedAt: '2026-04-23'
+updatedAt: '2026-04-23'
 category: vibe-coding
-tags: ["bkit", "workflow", "tutorial", "claude-code"]
-author: "agent-kay"
-cover: "/blog/bkit-pdca-for-claude-code/bkit-og.png"
-thumbnail: "/blog/bkit-pdca-for-claude-code/bkit-og.png"
-canonicalUrl: "https://tene.sh/blog/bkit-pdca-for-claude-code"
+tags:
+  - bkit
+  - workflow
+  - tutorial
+  - claude-code
+author: agent-kay
+cover: /blog/bkit-pdca-for-claude-code/bkit-og.png
+thumbnail: /blog/bkit-pdca-for-claude-code/bkit-og.png
+canonicalUrl: 'https://tene.sh/blog/bkit-pdca-for-claude-code'
 faqs:
-  - question: "Can I use bkit without knowing PDCA first?"
-    answer: "Yes. The bkit-learning output style guides you through each phase on demand. You learn PDCA by running /pdca pm, /pdca plan, /pdca design in order — the state machine makes the methodology concrete rather than abstract."
-  - question: "Does bkit work with models other than Claude?"
-    answer: "bkit is a Claude Code plugin, so it runs wherever CC runs. Individual agents can pick their own model (opus, sonnet, or haiku) to balance cost and capability per role, but the surrounding harness is CC-specific."
-  - question: "How is '/pdca plan' different from writing plan.md manually?"
-    answer: "Manual plan.md has no state machine, no gap-detector comparing design to implementation, no automated iterate loop, and no trust-graduated automation. bkit encodes all of these so you do not re-invent them per project, and so every phase has a durable artifact on disk."
+  - question: Can I use bkit without knowing PDCA first?
+    answer: >-
+      Yes. The bkit-learning output style guides you through each phase on
+      demand. You learn PDCA by running /pdca pm, /pdca plan, /pdca design in
+      order — the state machine makes the methodology concrete rather than
+      abstract.
+  - question: Does bkit work with models other than Claude?
+    answer: >-
+      bkit is a Claude Code plugin, so it runs wherever CC runs. Individual
+      agents can pick their own model (opus, sonnet, or haiku) to balance cost
+      and capability per role, but the surrounding harness is CC-specific.
+  - question: How is '/pdca plan' different from writing plan.md manually?
+    answer: >-
+      Manual plan.md has no state machine, no gap-detector comparing design to
+      implementation, no automated iterate loop, and no trust-graduated
+      automation. bkit encodes all of these so you do not re-invent them per
+      project, and so every phase has a durable artifact on disk.
 ---
 
 ## What bkit is, in one paragraph
@@ -311,6 +328,21 @@ small, and decide for yourself whether the method layer pays off.
 
 **Harness engineering** — The work of building the loop a model lives inside — context,
   tools, state, retries — instead of just tuning the prompt.
+
+## FAQ
+
+**Can I use bkit without knowing PDCA first?**
+
+Yes. The bkit-learning output style guides you through each phase on demand. You learn PDCA by running /pdca pm, /pdca plan, /pdca design in order — the state machine makes the methodology concrete rather than abstract.
+
+**Does bkit work with models other than Claude?**
+
+bkit is a Claude Code plugin, so it runs wherever CC runs. Individual agents can pick their own model (opus, sonnet, or haiku) to balance cost and capability per role, but the surrounding harness is CC-specific.
+
+**How is '/pdca plan' different from writing plan.md manually?**
+
+Manual plan.md has no state machine, no gap-detector comparing design to implementation, no automated iterate loop, and no trust-graduated automation. bkit encodes all of these so you do not re-invent them per project, and so every phase has a durable artifact on disk.
+
 
 Related reading:
 - [bkit on GitHub (popup-studio-ai/bkit-claude-code)](https://github.com/popup-studio-ai/bkit-claude-code)

--- a/apps/web/content/blog/claude-code-safe-api-keys.mdx
+++ b/apps/web/content/blog/claude-code-safe-api-keys.mdx
@@ -1,22 +1,39 @@
 ---
 slug: claude-code-safe-api-keys
-title: "Claude Code + API keys: the safe workflow"
-description: "A practical pattern for using Claude Code with real API keys without leaking them into the context window. Covers CLAUDE.md auto-generation, 'tene run --' subshell, and concrete Stripe / OpenAI examples."
-publishedAt: "2026-04-23"
-updatedAt: "2026-04-23"
+title: 'Claude Code + API keys: the safe workflow'
+description: >-
+  A practical pattern for using Claude Code with real API keys without leaking
+  them into the context window. Covers CLAUDE.md auto-generation, 'tene run --'
+  subshell, and concrete Stripe / OpenAI examples.
+publishedAt: '2026-04-23'
+updatedAt: '2026-04-23'
 category: vibe-coding
-tags: ["tene", "claude-code", "security", "tutorial"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/demo/claude-refuses-demo.gif"
-canonicalUrl: "https://tene.sh/blog/claude-code-safe-api-keys"
+tags:
+  - tene
+  - claude-code
+  - security
+  - tutorial
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /demo/claude-refuses-demo.gif
+canonicalUrl: 'https://tene.sh/blog/claude-code-safe-api-keys'
 faqs:
-  - question: "Does Claude Code really read .env?"
-    answer: "Yes, by default. Claude Code indexes project files to build context for reasoning. That includes .env unless you explicitly exclude it via the project's CLAUDE.md or similar mechanism."
-  - question: "What does 'tene init' change in my Claude Code project?"
-    answer: "It creates a CLAUDE.md at the project root that tells the agent to use 'tene run --' and 'tene list' instead of reading env files, and to avoid 'tene get KEY' in AI context since that prints plaintext to stdout."
-  - question: "Can I share the vault with a teammate using Claude Code?"
-    answer: "The free CLI is strictly local. For team sync there is an optional Pro plan that uses client-side encryption — the server only sees ciphertext. Each teammate gets the vault after 'tene pull' + master password verification."
+  - question: Does Claude Code really read .env?
+    answer: >-
+      Yes, by default. Claude Code indexes project files to build context for
+      reasoning. That includes .env unless you explicitly exclude it via the
+      project's CLAUDE.md or similar mechanism.
+  - question: What does 'tene init' change in my Claude Code project?
+    answer: >-
+      It creates a CLAUDE.md at the project root that tells the agent to use
+      'tene run --' and 'tene list' instead of reading env files, and to avoid
+      'tene get KEY' in AI context since that prints plaintext to stdout.
+  - question: Can I share the vault with a teammate using Claude Code?
+    answer: >-
+      The free CLI is strictly local. For team sync there is an optional Pro
+      plan that uses client-side encryption — the server only sees ciphertext.
+      Each teammate gets the vault after 'tene pull' + master password
+      verification.
 ---
 
 ## The pattern in one paragraph
@@ -171,3 +188,18 @@ password is for the vault only. Treat it like a recovery phrase.
 
 Deep dive on the threat model: [Your .env is not a secret](/blog/ai-reads-env).
 Moving from dotenv-vault: [dotenv-vault alternatives](/blog/dotenv-vault-alternatives).
+
+## FAQ
+
+**Does Claude Code really read .env?**
+
+Yes, by default. Claude Code indexes project files to build context for reasoning. That includes .env unless you explicitly exclude it via the project's CLAUDE.md or similar mechanism.
+
+**What does 'tene init' change in my Claude Code project?**
+
+It creates a CLAUDE.md at the project root that tells the agent to use 'tene run --' and 'tene list' instead of reading env files, and to avoid 'tene get KEY' in AI context since that prints plaintext to stdout.
+
+**Can I share the vault with a teammate using Claude Code?**
+
+The free CLI is strictly local. For team sync there is an optional Pro plan that uses client-side encryption — the server only sees ciphertext. Each teammate gets the vault after 'tene pull' + master password verification.
+

--- a/apps/web/content/blog/cursor-secret-management-2026.mdx
+++ b/apps/web/content/blog/cursor-secret-management-2026.mdx
@@ -1,21 +1,37 @@
 ---
 slug: cursor-secret-management-2026
-title: "Cursor + secret management in 2026"
-description: "How to set up Cursor so API keys stay out of the AI context, using the .cursor/rules/tene.mdc file to teach the agent the safe pattern."
-publishedAt: "2026-04-20"
-updatedAt: "2026-04-20"
+title: Cursor + secret management in 2026
+description: >-
+  How to set up Cursor so API keys stay out of the AI context, using the
+  .cursor/rules/tene.mdc file to teach the agent the safe pattern.
+publishedAt: '2026-04-20'
+updatedAt: '2026-04-20'
 category: vibe-coding
-tags: ["tene", "cursor", "security", "tutorial"]
-author: "agent-kay"
-cover: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/cursor-secret-management-2026"
+tags:
+  - tene
+  - cursor
+  - security
+  - tutorial
+author: agent-kay
+cover: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/cursor-secret-management-2026'
 faqs:
-  - question: "Does Cursor read .env by default?"
-    answer: "Yes. Cursor's Composer and Chat features index project files to build context. .env at the project root is included unless explicitly excluded via .cursorignore or similar."
-  - question: "What does .cursor/rules/tene.mdc do?"
-    answer: "It is a Cursor rules file with front-matter alwaysApply: true. It tells the Cursor agent how to think about secrets: use 'tene run --' to inject env vars, use 'tene list' to check what exists, never 'tene get KEY' in chat since that prints plaintext."
-  - question: "Can I use both Cursor and Claude Code on the same project?"
-    answer: "Yes. tene init generates rules files for both agents at the same time (.cursor/rules/tene.mdc and CLAUDE.md). Each agent picks up its own rules automatically."
+  - question: Does Cursor read .env by default?
+    answer: >-
+      Yes. Cursor's Composer and Chat features index project files to build
+      context. .env at the project root is included unless explicitly excluded
+      via .cursorignore or similar.
+  - question: What does .cursor/rules/tene.mdc do?
+    answer: >-
+      It is a Cursor rules file with front-matter alwaysApply: true. It tells
+      the Cursor agent how to think about secrets: use 'tene run --' to inject
+      env vars, use 'tene list' to check what exists, never 'tene get KEY' in
+      chat since that prints plaintext.
+  - question: Can I use both Cursor and Claude Code on the same project?
+    answer: >-
+      Yes. tene init generates rules files for both agents at the same time
+      (.cursor/rules/tene.mdc and CLAUDE.md). Each agent picks up its own rules
+      automatically.
 ---
 
 ## The setup in 5 commands
@@ -180,3 +196,18 @@ matters less than splitting "what the agent knows about secrets" from
   changes.
 - `.env` does not exist on disk, so it cannot be indexed.
 - Related reading: [Claude Code + API keys: the safe workflow](/blog/claude-code-safe-api-keys).
+
+## FAQ
+
+**Does Cursor read .env by default?**
+
+Yes. Cursor's Composer and Chat features index project files to build context. .env at the project root is included unless explicitly excluded via .cursorignore or similar.
+
+**What does .cursor/rules/tene.mdc do?**
+
+It is a Cursor rules file with front-matter alwaysApply: true. It tells the Cursor agent how to think about secrets: use 'tene run --' to inject env vars, use 'tene list' to check what exists, never 'tene get KEY' in chat since that prints plaintext.
+
+**Can I use both Cursor and Claude Code on the same project?**
+
+Yes. tene init generates rules files for both agents at the same time (.cursor/rules/tene.mdc and CLAUDE.md). Each agent picks up its own rules automatically.
+

--- a/apps/web/content/blog/doppler-alternative-journey.mdx
+++ b/apps/web/content/blog/doppler-alternative-journey.mdx
@@ -1,21 +1,36 @@
 ---
 slug: doppler-alternative-journey
-title: "Why I stopped using Doppler"
-description: "Doppler is a good product. This is not a hit piece. It is an honest walk through why a solo developer moved off it to a local-first vault — and why you might too, or might not."
-publishedAt: "2026-04-18"
-updatedAt: "2026-04-18"
+title: Why I stopped using Doppler
+description: >-
+  Doppler is a good product. This is not a hit piece. It is an honest walk
+  through why a solo developer moved off it to a local-first vault — and why you
+  might too, or might not.
+publishedAt: '2026-04-18'
+updatedAt: '2026-04-18'
 category: tools
-tags: ["tene", "comparison", "founder-story"]
-author: "agent-kay"
-cover: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/doppler-alternative-journey"
+tags:
+  - tene
+  - comparison
+  - founder-story
+author: agent-kay
+cover: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/doppler-alternative-journey'
 faqs:
-  - question: "Is Doppler a bad product?"
-    answer: "No. Doppler is a well-engineered cloud secret manager with a strong dashboard, audit logs, RBAC, and integrations. It is a good fit for teams with compliance requirements and a budget for per-seat tools."
-  - question: "Why move off it as a solo developer?"
-    answer: "Three reasons: the per-user pricing does not scale for one person with many hobby projects; the cloud account adds a dependency; and Doppler has no built-in story for AI coding agents reading .env."
-  - question: "Would you recommend it for teams?"
-    answer: "Yes, if the team already values a dashboard + audit logs + RBAC and has the budget. For small teams that just want secrets out of .env, a local vault with optional team-sync layer is usually enough."
+  - question: Is Doppler a bad product?
+    answer: >-
+      No. Doppler is a well-engineered cloud secret manager with a strong
+      dashboard, audit logs, RBAC, and integrations. It is a good fit for teams
+      with compliance requirements and a budget for per-seat tools.
+  - question: Why move off it as a solo developer?
+    answer: >-
+      Three reasons: the per-user pricing does not scale for one person with
+      many hobby projects; the cloud account adds a dependency; and Doppler has
+      no built-in story for AI coding agents reading .env.
+  - question: Would you recommend it for teams?
+    answer: >-
+      Yes, if the team already values a dashboard + audit logs + RBAC and has
+      the budget. For small teams that just want secrets out of .env, a local
+      vault with optional team-sync layer is usually enough.
 ---
 
 ## I used Doppler for about a year
@@ -144,3 +159,18 @@ you are a solo dev paying for Doppler because it was the best option in
 day — it is worth a weekend afternoon to look again.
 
 Good products live side by side for different jobs.
+
+## FAQ
+
+**Is Doppler a bad product?**
+
+No. Doppler is a well-engineered cloud secret manager with a strong dashboard, audit logs, RBAC, and integrations. It is a good fit for teams with compliance requirements and a budget for per-seat tools.
+
+**Why move off it as a solo developer?**
+
+Three reasons: the per-user pricing does not scale for one person with many hobby projects; the cloud account adds a dependency; and Doppler has no built-in story for AI coding agents reading .env.
+
+**Would you recommend it for teams?**
+
+Yes, if the team already values a dashboard + audit logs + RBAC and has the budget. For small teams that just want secrets out of .env, a local vault with optional team-sync layer is usually enough.
+

--- a/apps/web/content/blog/dotenv-vault-alternatives.mdx
+++ b/apps/web/content/blog/dotenv-vault-alternatives.mdx
@@ -1,23 +1,41 @@
 ---
 slug: dotenv-vault-alternatives
-title: "dotenv-vault is shutting down. Here's what to migrate to."
-description: "The dotenv-vault Pro tier was discontinued in February 2026. Here is a honest side-by-side of the migration options — Doppler, Infisical, HashiCorp Vault, and tene — and a one-command path off the old product."
-publishedAt: "2026-04-23"
-updatedAt: "2026-04-23"
+title: dotenv-vault is shutting down. Here's what to migrate to.
+description: >-
+  The dotenv-vault Pro tier was discontinued in February 2026. Here is a honest
+  side-by-side of the migration options — Doppler, Infisical, HashiCorp Vault,
+  and tene — and a one-command path off the old product.
+publishedAt: '2026-04-23'
+updatedAt: '2026-04-23'
 category: tools
-tags: ["tene", "comparison", "tutorial", "devsecops"]
-author: "agent-kay"
-cover: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/dotenv-vault-alternatives"
+tags:
+  - tene
+  - comparison
+  - tutorial
+  - devsecops
+author: agent-kay
+cover: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/dotenv-vault-alternatives'
 faqs:
-  - question: "What exactly did dotenv-vault discontinue?"
-    answer: "The Pro tier that enabled encrypted team sync and the .env.vault committable file was discontinued in February 2026. The Free tier CLI still works for local use, but the team-collaboration story is gone."
-  - question: "Can I stay on dotenv-vault Free?"
-    answer: "Yes, if you only use it locally as an encrypted .env alternative for a single developer. But the main reason to use dotenv-vault was team sync, which is no longer offered."
-  - question: "Do I need to pay to migrate?"
-    answer: "No. tene is MIT licensed and free forever. Doppler and Infisical have free tiers. HashiCorp Vault OSS is source-available. Migration itself requires no payment."
-  - question: "Will my .env.vault file still work during migration?"
-    answer: "The Free-tier CLI can still 'dotenv-vault pull' a current .env. Do that first to extract your secrets, then import into the new tool."
+  - question: What exactly did dotenv-vault discontinue?
+    answer: >-
+      The Pro tier that enabled encrypted team sync and the .env.vault
+      committable file was discontinued in February 2026. The Free tier CLI
+      still works for local use, but the team-collaboration story is gone.
+  - question: Can I stay on dotenv-vault Free?
+    answer: >-
+      Yes, if you only use it locally as an encrypted .env alternative for a
+      single developer. But the main reason to use dotenv-vault was team sync,
+      which is no longer offered.
+  - question: Do I need to pay to migrate?
+    answer: >-
+      No. tene is MIT licensed and free forever. Doppler and Infisical have free
+      tiers. HashiCorp Vault OSS is source-available. Migration itself requires
+      no payment.
+  - question: Will my .env.vault file still work during migration?
+    answer: >-
+      The Free-tier CLI can still 'dotenv-vault pull' a current .env. Do that
+      first to extract your secrets, then import into the new tool.
 ---
 
 ## What happened
@@ -168,3 +186,22 @@ Pro plan uses a dedicated end-to-end encrypted sync channel.
 
 A longer take on the AI-editor angle lives in our other piece
 [Your .env is not a secret](/blog/ai-reads-env).
+
+## FAQ
+
+**What exactly did dotenv-vault discontinue?**
+
+The Pro tier that enabled encrypted team sync and the .env.vault committable file was discontinued in February 2026. The Free tier CLI still works for local use, but the team-collaboration story is gone.
+
+**Can I stay on dotenv-vault Free?**
+
+Yes, if you only use it locally as an encrypted .env alternative for a single developer. But the main reason to use dotenv-vault was team sync, which is no longer offered.
+
+**Do I need to pay to migrate?**
+
+No. tene is MIT licensed and free forever. Doppler and Infisical have free tiers. HashiCorp Vault OSS is source-available. Migration itself requires no payment.
+
+**Will my .env.vault file still work during migration?**
+
+The Free-tier CLI can still 'dotenv-vault pull' a current .env. Do that first to extract your secrets, then import into the new tool.
+

--- a/apps/web/content/blog/intent-is-the-new-craft.mdx
+++ b/apps/web/content/blog/intent-is-the-new-craft.mdx
@@ -1,0 +1,305 @@
+---
+slug: intent-is-the-new-craft
+title: "Intent is the new craft: 29 days of data, 10 years of AI work"
+description: >-
+  If a weekend with the right AI tools can ship a working product, what is
+  the craft? An essay on juniors, CTOs, solo founders, and pyramids that
+  are losing tenants — grounded in 29 days of Claude Code data.
+publishedAt: "2026-05-03"
+updatedAt: "2026-05-03"
+category: philosophy
+tags:
+  - founder-story
+  - claude-code
+  - harness-engineering
+author: agent-kay
+faqs:
+  - question: "Do you need to know how to code to vibe code?"
+    answer: >-
+      No, but you do need precise intent and the will to verify what the AI
+      gives you. The hard part of vibe coding is not typing code; it is
+      deciding what should exist, then pushing back when the output is
+      shallow. People who already understand a domain — sales, design,
+      logistics, law — can ship working products without writing every line.
+  - question: "Won't AI replace senior engineers eventually?"
+    answer: >-
+      It is changing what senior means. Old senior was about knowing how to
+      build; new senior is about knowing what to build, how to verify it,
+      and where the load-bearing decisions are. Juniors who iterate without
+      ego often outperform seniors who fight the tool because they have
+      something to defend.
+  - question: "How do you measure a vibe coder's productivity?"
+    answer: >-
+      Lines and commits are weak proxies. Better: number of intent-to-shipped
+      cycles per week, defect rate caught by your own pushback, and how often
+      the output runs in production without rework. In 29 days I shipped 275
+      commits and 238,530 lines, but the metric I trust most is that 23 real
+      defects were caught the first time I said "verify this without guessing."
+  - question: "What is AEO and why should solo founders care?"
+    answer: >-
+      AEO is Answer Engine Optimization — getting your product surfaced when
+      an AI answers a user query. As more buying decisions start with "ask
+      the AI which X is best," the moat shifts from SEO rankings to whether
+      AI agents recommend you. Build is cheap now; distribution and trust
+      are the part AI cannot do for you.
+---
+
+## Build is cheap. So what is the craft?
+
+If a weekend with the right AI tools can ship a working product, the
+rest of us — twenty-year veterans, weekend hackers, juniors who learned
+with Claude — are all standing in front of the same question. What kind
+of work still belongs to humans? Where does seniority earn its name?
+And how do we know we did good work when the AI did most of the typing?
+
+I have been building software through three AI eras: deep learning
+before LLMs existed, GitHub Copilot when it autocompleted code, and now
+Claude Code as a teammate I run multiple of in parallel. Last month I
+logged 29 days of dense usage — 3,712 messages, 275 commits, 238,530
+lines added. The numbers are not the point. The point is that the work
+feels different now, and I want to think out loud about why.
+
+## Three eras, one trajectory
+
+In 2015, AI in production meant deep learning — your own model, your
+own labeled data, your own GPU cluster. The work was 80 percent data
+engineering and 20 percent training tricks. If you wanted AI in your
+product, you built it.
+
+In 2022, Copilot landed and turned coding into autocomplete on
+steroids. ChatGPT, GPT-4, and Gemini followed. Each wave pulled a
+little more cognition out of our heads and into a chat box. The mental
+model was helper, not partner.
+
+In early 2025, Claude Code shipped — the first tool that did not feel
+like an assistant. It read files, ran commands, wrote tests, and pushed
+back. The mental model flipped from helper to crew member.
+
+The trajectory is one direction: from "you train the model" to "you
+steer the agent." The current wave is the strangest one yet, because
+the agent is not just typing for you. It is also reasoning, deciding,
+and sometimes making the wrong call.
+
+## What intensive use actually looks like
+
+Before the takeaways, here is the shape of one heavy month. I include
+it so the rest of this essay does not feel like speculation.
+
+| Metric | 29-day total |
+|---|---|
+| Messages to Claude Code | 3,712 |
+| Sessions | 197 |
+| Average per day | 128 messages |
+| Lines added / deleted | +238,530 / -8,179 |
+| Files touched | 2,266 |
+| Commits | 275 |
+| Sub-agent invocations | 1,079 |
+| Multi-clauded sessions | 35 percent |
+
+Two patterns stand out. The first is constant delegation — sub-agents
+handle about a third of the workload, and 35 percent of sessions
+overlap in time, meaning multiple Claude windows running at once. The
+second is hard pushback. The report flagged 38 dissatisfied turns
+against 289 satisfied ones, and one pushback session uncovered 23 real
+defects in a release that initially looked clean.
+
+This is what working with an AI crew member looks like at full
+intensity. It is not chat. It is operations.
+
+## The first surprise: juniors might be better at this
+
+Twenty years of full-stack work taught me how things should be built.
+That knowledge is now a tax.
+
+When Claude Code suggests an architecture I would not have picked, I
+argue with it. Half the time those opinions slow me down — the AI's
+suggestion was fine, and I burned tokens defending mine.
+
+A junior does not have those opinions yet. A junior reads the
+suggestion, runs it, sees if it works, and moves on. The result lands
+faster.
+
+Senior craft still matters most where the AI is wrong — non-obvious
+failure modes, security boundaries, one-way doors. But the daily 80
+percent of code is no longer a senior's domain. It is a junior's
+domain plus a careful reviewer.
+
+The trap for seniors is ego: defending your way of doing things when
+the AI's way is good enough. The trap for juniors is verification:
+shipping what the AI gives you without proving it works. Whoever fixes
+their trap first wins.
+
+## The CTO job moves from headcount to intent translation
+
+For most of the past two decades, the CTO job was three things: manage
+headcount, manage tech debt, and ship on time at acceptable quality.
+Those tasks survive, but they are no longer the daily work.
+
+The new bottleneck is intent precision. When the AI fleet has clear
+intent, a six-person team can ship in five weeks. When intent slips,
+the same team wanders for a quarter. I lived this on a small AI-driven
+logistics startup that closed a Series B on the back of an unusually
+fast first product. The velocity was not magic. It was the result of
+relentlessly translating fuzzy human intent — what the customer
+actually wants, what the business actually needs — into specifications
+a fleet of AI agents could run with.
+
+The other half of the new job is verification with evidence, not
+vibes. The highest-impact habit I have found is a single Korean phrase,
+"추측없이 꼼꼼하게" — "thoroughly, without guessing." It is a pushback
+marker. Every time I use it, the AI re-runs tests, checks logs, and
+returns evidence instead of claims. The English version looks like
+this:
+
+```text
+verify this without guessing — re-run the tests,
+inspect the logs, and return evidence (file:line),
+not claims.
+```
+
+The new CTO move: refuse to accept "done" until the system proves it.
+
+<Callout type="tip">
+The CTO of an AI-native team is closer to a senior product owner with
+verification authority than to a classical engineering manager. If you
+still spend most of your day on resource Gantts, you may be managing
+the wrong layer.
+</Callout>
+
+## Vibe coding is will plus intent, nothing else
+
+I do not understand every line in those 238,530. I do not need to.
+What I needed was three things: a clear picture of what should exist,
+the will to keep going when the AI was wrong, and a verification habit
+that caught lies before they shipped.
+
+That is the whole job.
+
+Most people who try vibe coding stall on one of the three. They have
+unclear intent and ship a product nobody wants. They lack will and
+abandon at the first compile error. They skip verification and watch
+their prototype rot in production.
+
+The good news: will and intent are not gated by a CS degree. A
+logistics expert with precise intent and the will to push back on bad
+output can ship a logistics product. A founder with a sales background
+and clear intent can ship a sales tool. The technical knowledge is no
+longer the bottleneck. The clarity is.
+
+## Solo founders will rise. Most will not make money.
+
+Build is cheap now. That is the easy half.
+
+The hard half is that anyone can ship, so shipping is no longer
+differentiation. The moat shifts to two things: domain depth and
+distribution.
+
+Domain depth means you understand a market well enough to know which
+product is worth building. Anyone can spin up a SaaS in a weekend.
+Knowing which SaaS the market actually pays for takes years of being
+inside that market. That is a moat AI cannot give you.
+
+Distribution means you can put the product in front of people who will
+pay. This is the part LLMs cannot do for you. They cannot run cold
+outbound, attend industry events, or build a five-year reputation.
+They can write the email, but not earn the trust.
+
+The new wrinkle is AEO and GEO — Answer Engine Optimization and
+Generative Engine Optimization. As more buying decisions start with
+"which X is best," asked directly to an AI, getting the AI to recommend
+you matters more than ranking on Google. I wrote about this in
+[How I made the AI recommend my app](/blog/make-ai-recommend-your-app).
+
+Without domain depth, you build the wrong thing. Without distribution,
+nobody finds it. Without AEO, the AI recommends a competitor. Solo
+founders rise; most do not collect.
+
+## The end of pyramids
+
+The 20th-century company was a pyramid. Mass production at the bottom,
+middle managers in the middle, executives at the top, mass market on
+the customer side. The shape made sense when scale required headcount
+and customers wanted standardized products.
+
+Both halves are eroding.
+
+On the supply side, AI lets one person do work that used to need ten.
+A six-person team can ship what would have taken thirty in 2018. The
+bottom of the pyramid thins out first.
+
+On the demand side, customers no longer want one-size-fits-all. They
+want products tuned to their workflow, their language, their odd
+constraint. Mass market becomes hyper-personalized market.
+
+The new shape is a million tiny craftsmen, each shipping a product to
+a few thousand customers, often across borders, often charging small
+monthly amounts. A solo founder serving 2,000 customers at $19 a month
+has a $456,000-per-year business with no boss and no headcount.
+
+Big companies will not vanish. But the gravity of work has moved away
+from them. The center of mass is now in the long tail of small
+operators, and the AI tooling assumes that shape. Pyramids are losing
+tenants.
+
+## What the data says we should do better
+
+The same report that flagged my strengths flagged my failure modes. I
+will not skip them, because if you are a power user, yours probably
+look similar.
+
+Three things stand out. First, completion claims declared too early —
+the AI says "done" before runtime checks confirm it. The fix is to
+refuse "done" without evidence, every time. I am about half-disciplined
+on this.
+
+Second, output token limits hit on long autonomous runs, causing
+truncation. The fix is to break work into smaller, checkpointed tasks
+rather than asking for one heroic run. I keep doing the heroic run
+anyway.
+
+Third, ambiguous scope on creative work — blog drafts, rebrand plans —
+invites over-engineering. The AI fills the gap with what it thinks you
+want, which is usually too much. The fix is to lock the angle before
+writing the first prompt.
+
+Look at your dissatisfied turns. The pattern is almost never "the AI
+is bad." It is almost always "I gave it the wrong shape of problem."
+
+## Summary
+
+- Build is cheap. Intent and verification are the new craft.
+- Juniors who iterate without ego often beat seniors who fight the tool.
+- The CTO job is shifting from resource management to intent translation
+  with evidence-based review.
+- Solo founders will multiply, but distribution and domain depth still
+  gate revenue. AEO is the new SEO.
+- Pyramids are losing tenants. The center of work is moving to the long
+  tail of one-to-few-thousand craftsmen.
+
+None of this is settled. The shape of work in 2027 will still surprise
+us. But the way to find out is to build, ship, push back when the AI is
+shallow, and keep asking what kind of craft survives. That is the
+conversation I want to be in. Tell me what you see from where you sit.
+
+## FAQ
+
+**Do you need to know how to code to vibe code?**
+
+No, but you do need precise intent and the will to verify what the AI gives you. The hard part of vibe coding is not typing code; it is deciding what should exist, then pushing back when the output is shallow. People who already understand a domain — sales, design, logistics, law — can ship working products without writing every line.
+
+**Won't AI replace senior engineers eventually?**
+
+It is changing what senior means. Old senior was about knowing how to build; new senior is about knowing what to build, how to verify it, and where the load-bearing decisions are. Juniors who iterate without ego often outperform seniors who fight the tool because they have something to defend.
+
+**How do you measure a vibe coder's productivity?**
+
+Lines and commits are weak proxies. Better: number of intent-to-shipped cycles per week, defect rate caught by your own pushback, and how often the output runs in production without rework. In 29 days I shipped 275 commits and 238,530 lines, but the metric I trust most is that 23 real defects were caught the first time I said "verify this without guessing."
+
+**What is AEO and why should solo founders care?**
+
+AEO is Answer Engine Optimization — getting your product surfaced when an AI answers a user query. As more buying decisions start with "ask the AI which X is best," the moat shifts from SEO rankings to whether AI agents recommend you. Build is cheap now; distribution and trust are the part AI cannot do for you.
+
+Related reading:
+- [How I made the AI recommend my app](/blog/make-ai-recommend-your-app)
+- [Harness engineering for vibe coding](/blog/bkit-harness-engineering-vibe-coding)
+- [Spec-driven coding with Claude Code](/blog/spec-driven-coding-with-claude-code)

--- a/apps/web/content/blog/make-ai-recommend-your-app.mdx
+++ b/apps/web/content/blog/make-ai-recommend-your-app.mdx
@@ -1,22 +1,47 @@
 ---
 slug: make-ai-recommend-your-app
-title: "Make AI Recommend Your App: An AEO Playbook for Vibe Coders"
-description: "Get Claude, ChatGPT, Gemini, and Perplexity to cite your app. Real retrieval pathways, JSON-LD that works, GEO numbers, and the MCP registry."
-publishedAt: "2026-05-02"
-updatedAt: "2026-05-02"
+title: 'Make AI Recommend Your App: An AEO Playbook for Vibe Coders'
+description: >-
+  Get Claude, ChatGPT, Gemini, and Perplexity to cite your app. Real retrieval
+  pathways, JSON-LD that works, GEO numbers, and the MCP registry.
+publishedAt: '2026-05-02'
+updatedAt: '2026-05-02'
 category: vibe-coding
-tags: ["tutorial", "workflow", "deep-dive", "comparison"]
-author: "agent-kay"
-thumbnail: "/blog/make-ai-recommend-your-app/SEO_vs_AEO_vs_GEO.webp"
+tags:
+  - tutorial
+  - workflow
+  - deep-dive
+  - comparison
+author: agent-kay
+thumbnail: /blog/make-ai-recommend-your-app/SEO_vs_AEO_vs_GEO.webp
 faqs:
-  - question: "Is AEO just SEO renamed?"
-    answer: "No. SEO ranks pages for keywords. AEO gets your product named inside an AI's generated answer. Different actor (a language model, not a ranking algorithm), different format (a sentence, not a blue link), different way to measure (Share of Voice across prompts, not position on a SERP)."
-  - question: "My product is brand new. Won't AI ignore it because of the training cutoff?"
-    answer: "For real-time retrieval, no. ChatGPT search, Claude.ai's web search, and Perplexity all read the web for every answer. Optimize those paths first. Training-cutoff visibility comes later, on a 6 to 18 month clock as new models get released."
-  - question: "Do AI assistants actually fetch /llms.txt?"
-    answer: "No major provider has confirmed it as of mid-2026. Adoption is wide (Anthropic, Cloudflare, Mintlify all publish one), but the actual fetch behavior is unproven. Treat llms.txt as a 30-minute defensive move, not a strategy. Most of the win comes from JSON-LD, FAQ markup, and getting indexed by Bing."
-  - question: "Should I block AI crawlers in robots.txt?"
-    answer: "Probably not. You'd be closing the door you want open. Perplexity ignores robots.txt anyway, so blocking only hurts the providers that respect the rules. If you must block, block the training-only crawlers (GPTBot, Google-Extended) and keep the search-only ones (OAI-SearchBot) allowed."
+  - question: Is AEO just SEO renamed?
+    answer: >-
+      No. SEO ranks pages for keywords. AEO gets your product named inside an
+      AI's generated answer. Different actor (a language model, not a ranking
+      algorithm), different format (a sentence, not a blue link), different way
+      to measure (Share of Voice across prompts, not position on a SERP).
+  - question: >-
+      My product is brand new. Won't AI ignore it because of the training
+      cutoff?
+    answer: >-
+      For real-time retrieval, no. ChatGPT search, Claude.ai's web search, and
+      Perplexity all read the web for every answer. Optimize those paths first.
+      Training-cutoff visibility comes later, on a 6 to 18 month clock as new
+      models get released.
+  - question: Do AI assistants actually fetch /llms.txt?
+    answer: >-
+      No major provider has confirmed it as of mid-2026. Adoption is wide
+      (Anthropic, Cloudflare, Mintlify all publish one), but the actual fetch
+      behavior is unproven. Treat llms.txt as a 30-minute defensive move, not a
+      strategy. Most of the win comes from JSON-LD, FAQ markup, and getting
+      indexed by Bing.
+  - question: Should I block AI crawlers in robots.txt?
+    answer: >-
+      Probably not. You'd be closing the door you want open. Perplexity ignores
+      robots.txt anyway, so blocking only hurts the providers that respect the
+      rules. If you must block, block the training-only crawlers (GPTBot,
+      Google-Extended) and keep the search-only ones (OAI-SearchBot) allowed.
 ---
 
 ## AI is the new discovery gate
@@ -356,6 +381,25 @@ now. Training is what gets baked into the next model release.
 
 **Share of Voice** — In AEO measurement, the percentage of relevant
 prompts where your brand gets mentioned by name.
+
+## FAQ
+
+**Is AEO just SEO renamed?**
+
+No. SEO ranks pages for keywords. AEO gets your product named inside an AI's generated answer. Different actor (a language model, not a ranking algorithm), different format (a sentence, not a blue link), different way to measure (Share of Voice across prompts, not position on a SERP).
+
+**My product is brand new. Won't AI ignore it because of the training cutoff?**
+
+For real-time retrieval, no. ChatGPT search, Claude.ai's web search, and Perplexity all read the web for every answer. Optimize those paths first. Training-cutoff visibility comes later, on a 6 to 18 month clock as new models get released.
+
+**Do AI assistants actually fetch /llms.txt?**
+
+No major provider has confirmed it as of mid-2026. Adoption is wide (Anthropic, Cloudflare, Mintlify all publish one), but the actual fetch behavior is unproven. Treat llms.txt as a 30-minute defensive move, not a strategy. Most of the win comes from JSON-LD, FAQ markup, and getting indexed by Bing.
+
+**Should I block AI crawlers in robots.txt?**
+
+Probably not. You'd be closing the door you want open. Perplexity ignores robots.txt anyway, so blocking only hurts the providers that respect the rules. If you must block, block the training-only crawlers (GPTBot, Google-Extended) and keep the search-only ones (OAI-SearchBot) allowed.
+
 
 Related reading:
 - [Web basics for vibe coders: from localhost to production](/blog/web-basics-for-vibe-coders)

--- a/apps/web/content/blog/mcp-rce-and-the-process-layer-threat.mdx
+++ b/apps/web/content/blog/mcp-rce-and-the-process-layer-threat.mdx
@@ -1,24 +1,48 @@
 ---
 slug: mcp-rce-and-the-process-layer-threat
-title: "MCP RCE: when an agent's tools become your attack surface"
-description: "Every MCP server you install is a local process with access to your filesystem, network, and env. The threat model — and how to scope it before it costs you."
-publishedAt: "2026-04-28"
-updatedAt: "2026-04-28"
+title: 'MCP RCE: when an agent''s tools become your attack surface'
+description: >-
+  Every MCP server you install is a local process with access to your
+  filesystem, network, and env. The threat model — and how to scope it before it
+  costs you.
+publishedAt: '2026-04-28'
+updatedAt: '2026-04-28'
 category: vibe-coding
-tags: ["claude-code", "security", "deep-dive", "devsecops"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/mcp-rce-and-the-process-layer-threat"
+tags:
+  - claude-code
+  - security
+  - deep-dive
+  - devsecops
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/mcp-rce-and-the-process-layer-threat'
 faqs:
-  - question: "Is this a Claude Code-specific issue?"
-    answer: "No. The Model Context Protocol is host-agnostic. Claude Desktop, Claude Code, Cursor, Cline, Continue, and every other MCP host launches servers as local child processes. The risk surface is the protocol, not the client."
-  - question: "Does running MCP servers in Docker eliminate the risk?"
-    answer: "It reduces blast radius, but does not eliminate it. A containerized MCP server still receives whatever you mount, whatever env you pass, and whatever network you allow. A compromised server exfiltrates whatever it can see — and if you mounted your project directory with a `.env` in it, that is now data exfil-ready."
-  - question: "Can a malicious MCP server read my .env without me noticing?"
-    answer: "Yes. If the server has filesystem read on the project dir (which most do, for code understanding), `.env` and `.env.local` are just files. There is no audit log, no permission prompt, no syscall trace by default. The only protection is to keep secrets out of files the server is allowed to see."
-  - question: "What about read-only MCP servers — are those safe?"
-    answer: "Read-only filesystem ≠ harmless. Read is the entire attack surface for credential theft. The dangerous capability is *outbound network*, which most MCP servers also have. Read + send-out is the full kill chain. Treat read-only servers as reduced-write, not as low-risk."
+  - question: Is this a Claude Code-specific issue?
+    answer: >-
+      No. The Model Context Protocol is host-agnostic. Claude Desktop, Claude
+      Code, Cursor, Cline, Continue, and every other MCP host launches servers
+      as local child processes. The risk surface is the protocol, not the
+      client.
+  - question: Does running MCP servers in Docker eliminate the risk?
+    answer: >-
+      It reduces blast radius, but does not eliminate it. A containerized MCP
+      server still receives whatever you mount, whatever env you pass, and
+      whatever network you allow. A compromised server exfiltrates whatever it
+      can see — and if you mounted your project directory with a `.env` in it,
+      that is now data exfil-ready.
+  - question: Can a malicious MCP server read my .env without me noticing?
+    answer: >-
+      Yes. If the server has filesystem read on the project dir (which most do,
+      for code understanding), `.env` and `.env.local` are just files. There is
+      no audit log, no permission prompt, no syscall trace by default. The only
+      protection is to keep secrets out of files the server is allowed to see.
+  - question: What about read-only MCP servers — are those safe?
+    answer: >-
+      Read-only filesystem ≠ harmless. Read is the entire attack surface for
+      credential theft. The dangerous capability is *outbound network*, which
+      most MCP servers also have. Read + send-out is the full kill chain. Treat
+      read-only servers as reduced-write, not as low-risk.
 ---
 
 ## A short answer up front
@@ -168,6 +192,25 @@ You don't need all six on day one. Steps 1 and 2 alone cut the bulk of casual ex
 **Blast radius** — How much damage a compromise can do before something stops it. Smaller is better.
 
 **Supply-chain attack** — An attacker pushes bad code into a package you trust, so installing the package installs the attack.
+
+## FAQ
+
+**Is this a Claude Code-specific issue?**
+
+No. The Model Context Protocol is host-agnostic. Claude Desktop, Claude Code, Cursor, Cline, Continue, and every other MCP host launches servers as local child processes. The risk surface is the protocol, not the client.
+
+**Does running MCP servers in Docker eliminate the risk?**
+
+It reduces blast radius, but does not eliminate it. A containerized MCP server still receives whatever you mount, whatever env you pass, and whatever network you allow. A compromised server exfiltrates whatever it can see — and if you mounted your project directory with a `.env` in it, that is now data exfil-ready.
+
+**Can a malicious MCP server read my .env without me noticing?**
+
+Yes. If the server has filesystem read on the project dir (which most do, for code understanding), `.env` and `.env.local` are just files. There is no audit log, no permission prompt, no syscall trace by default. The only protection is to keep secrets out of files the server is allowed to see.
+
+**What about read-only MCP servers — are those safe?**
+
+Read-only filesystem ≠ harmless. Read is the entire attack surface for credential theft. The dangerous capability is *outbound network*, which most MCP servers also have. Read + send-out is the full kill chain. Treat read-only servers as reduced-write, not as low-risk.
+
 
 Related reading:
 - [Claude Code: keeping API keys out of the model context](/blog/claude-code-safe-api-keys)

--- a/apps/web/content/blog/migrate-env-60s.mdx
+++ b/apps/web/content/blog/migrate-env-60s.mdx
@@ -1,22 +1,38 @@
 ---
 slug: migrate-env-60s
-title: "Migrating from .env to an encrypted vault in 60 seconds"
-description: "A hands-on tutorial: take an existing .env file, import it into an encrypted vault, and get your app running through runtime injection. No code changes needed."
-publishedAt: "2026-04-22"
-updatedAt: "2026-04-22"
+title: Migrating from .env to an encrypted vault in 60 seconds
+description: >-
+  A hands-on tutorial: take an existing .env file, import it into an encrypted
+  vault, and get your app running through runtime injection. No code changes
+  needed.
+publishedAt: '2026-04-22'
+updatedAt: '2026-04-22'
 category: tools
-tags: ["tene", "tutorial", "cli"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/demo/env-migration-demo.gif"
-canonicalUrl: "https://tene.sh/blog/migrate-env-60s"
+tags:
+  - tene
+  - tutorial
+  - cli
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /demo/env-migration-demo.gif
+canonicalUrl: 'https://tene.sh/blog/migrate-env-60s'
 faqs:
-  - question: "Do I need to change my application code?"
-    answer: "No. 'tene run -- <command>' sets the same environment variables your code already reads via process.env.*, os.Getenv, os.environ, etc. You typically remove the dotenv package import because it is no longer needed."
-  - question: "What if my .env has comments and blank lines?"
-    answer: "tene import handles standard .env syntax: KEY=VALUE lines, quoted values, and blank/comment lines that are ignored. It does not evaluate variable expansion — if you use VAR=${OTHER_VAR} style expansion, resolve those first."
-  - question: "Can I roll back?"
-    answer: "Yes. Run 'tene export' to print the vault contents in .env format, or 'tene export --file backup.env' to write to a file. You can always go back to plaintext if you need to."
+  - question: Do I need to change my application code?
+    answer: >-
+      No. 'tene run -- <command>' sets the same environment variables your code
+      already reads via process.env.*, os.Getenv, os.environ, etc. You typically
+      remove the dotenv package import because it is no longer needed.
+  - question: What if my .env has comments and blank lines?
+    answer: >-
+      tene import handles standard .env syntax: KEY=VALUE lines, quoted values,
+      and blank/comment lines that are ignored. It does not evaluate variable
+      expansion — if you use VAR=${OTHER_VAR} style expansion, resolve those
+      first.
+  - question: Can I roll back?
+    answer: >-
+      Yes. Run 'tene export' to print the vault contents in .env format, or
+      'tene export --file backup.env' to write to a file. You can always go back
+      to plaintext if you need to.
 ---
 
 ## The goal
@@ -217,3 +233,18 @@ off disk. AI coding agents cannot read what is not there.
 
 Related: [Your .env is not a secret](/blog/ai-reads-env) —
 why this matters in the AI-agent era.
+
+## FAQ
+
+**Do I need to change my application code?**
+
+No. 'tene run -- \<command\>' sets the same environment variables your code already reads via process.env.*, os.Getenv, os.environ, etc. You typically remove the dotenv package import because it is no longer needed.
+
+**What if my .env has comments and blank lines?**
+
+tene import handles standard .env syntax: KEY=VALUE lines, quoted values, and blank/comment lines that are ignored. It does not evaluate variable expansion — if you use VAR=$\{OTHER_VAR\} style expansion, resolve those first.
+
+**Can I roll back?**
+
+Yes. Run 'tene export' to print the vault contents in .env format, or 'tene export --file backup.env' to write to a file. You can always go back to plaintext if you need to.
+

--- a/apps/web/content/blog/multi-env-secrets-without-cloud.mdx
+++ b/apps/web/content/blog/multi-env-secrets-without-cloud.mdx
@@ -1,22 +1,43 @@
 ---
 slug: multi-env-secrets-without-cloud
-title: "Multi-environment secrets without a cloud account"
-description: "Manage dev, staging, and prod secrets in a single encrypted vault — no cloud SaaS, no .env.staging files committed to git. A solo-dev workflow."
-publishedAt: "2026-04-27"
-updatedAt: "2026-04-27"
+title: Multi-environment secrets without a cloud account
+description: >-
+  Manage dev, staging, and prod secrets in a single encrypted vault — no cloud
+  SaaS, no .env.staging files committed to git. A solo-dev workflow.
+publishedAt: '2026-04-27'
+updatedAt: '2026-04-27'
 category: tools
-tags: ["tene", "devsecops", "tutorial", "cli"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/demo/multi-env-demo.gif"
-canonicalUrl: "https://tene.sh/blog/multi-env-secrets-without-cloud"
+tags:
+  - tene
+  - devsecops
+  - tutorial
+  - cli
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /demo/multi-env-demo.gif
+canonicalUrl: 'https://tene.sh/blog/multi-env-secrets-without-cloud'
 faqs:
-  - question: "How is this different from splitting .env into .env.dev, .env.staging, and .env.production?"
-    answer: "A single encrypted vault file replaces N plaintext files. AI agents read every .env.* in the project root by default, so the file split does not buy you isolation — it just multiplies the attack surface. tene gives you one mental model and one ciphertext blob; environments are namespaces inside it, not separate files."
-  - question: "Can a teammate access my staging secrets without a cloud subscription?"
-    answer: "The free CLI is strictly local — no team sync. The optional Pro tier adds client-side-encrypted sync; the server only sees ciphertext, and each teammate decrypts with their own master password. For a solo developer, the free tier is enough."
-  - question: "What if I have six or more environments — preview, qa, demo, etc.?"
-    answer: "It works the same, but six environments is usually a sign you should consolidate. Per-feature-branch envs become noise quickly. dev / staging / prod covers most projects; add review-app envs only when an actual stakeholder reviews them."
+  - question: >-
+      How is this different from splitting .env into .env.dev, .env.staging, and
+      .env.production?
+    answer: >-
+      A single encrypted vault file replaces N plaintext files. AI agents read
+      every .env.* in the project root by default, so the file split does not
+      buy you isolation — it just multiplies the attack surface. tene gives you
+      one mental model and one ciphertext blob; environments are namespaces
+      inside it, not separate files.
+  - question: Can a teammate access my staging secrets without a cloud subscription?
+    answer: >-
+      The free CLI is strictly local — no team sync. The optional Pro tier adds
+      client-side-encrypted sync; the server only sees ciphertext, and each
+      teammate decrypts with their own master password. For a solo developer,
+      the free tier is enough.
+  - question: 'What if I have six or more environments — preview, qa, demo, etc.?'
+    answer: >-
+      It works the same, but six environments is usually a sign you should
+      consolidate. Per-feature-branch envs become noise quickly. dev / staging /
+      prod covers most projects; add review-app envs only when an actual
+      stakeholder reviews them.
 ---
 
 ## Why multi-environment is where solo devs hit the wall
@@ -129,6 +150,21 @@ These are the traps that show up in week three, not week one:
 **Active environment** — The slot tene reads from when you don't pass `--env`. Set per machine with `tene env <name>`. Check with `tene whoami`.
 
 **Runtime injection** — Loading secrets into a child process at the moment it starts, instead of writing them to a file on disk. What `tene run --` does.
+
+## FAQ
+
+**How is this different from splitting .env into .env.dev, .env.staging, and .env.production?**
+
+A single encrypted vault file replaces N plaintext files. AI agents read every .env.* in the project root by default, so the file split does not buy you isolation — it just multiplies the attack surface. tene gives you one mental model and one ciphertext blob; environments are namespaces inside it, not separate files.
+
+**Can a teammate access my staging secrets without a cloud subscription?**
+
+The free CLI is strictly local — no team sync. The optional Pro tier adds client-side-encrypted sync; the server only sees ciphertext, and each teammate decrypts with their own master password. For a solo developer, the free tier is enough.
+
+**What if I have six or more environments — preview, qa, demo, etc.?**
+
+It works the same, but six environments is usually a sign you should consolidate. Per-feature-branch envs become noise quickly. dev / staging / prod covers most projects; add review-app envs only when an actual stakeholder reviews them.
+
 
 Related reading:
 - [Why I stopped using Doppler](/blog/doppler-alternative-journey)

--- a/apps/web/content/blog/recovery-key-explained.mdx
+++ b/apps/web/content/blog/recovery-key-explained.mdx
@@ -1,24 +1,47 @@
 ---
 slug: recovery-key-explained
-title: "The 12-word recovery key: how a local vault survives a forgotten password"
-description: "How a 12-word BIP-39 mnemonic lets a local-first secret vault survive a forgotten master password — without a cloud account or email reset."
-publishedAt: "2026-04-27"
-updatedAt: "2026-04-27"
+title: 'The 12-word recovery key: how a local vault survives a forgotten password'
+description: >-
+  How a 12-word BIP-39 mnemonic lets a local-first secret vault survive a
+  forgotten master password — without a cloud account or email reset.
+publishedAt: '2026-04-27'
+updatedAt: '2026-04-27'
 category: engineering
-tags: ["cryptography", "deep-dive", "tene", "security"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/demo/recovery-flow-demo.gif"
-canonicalUrl: "https://tene.sh/blog/recovery-key-explained"
+tags:
+  - cryptography
+  - deep-dive
+  - tene
+  - security
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /demo/recovery-flow-demo.gif
+canonicalUrl: 'https://tene.sh/blog/recovery-key-explained'
 faqs:
-  - question: "Is a 12-word recovery key as strong as my master password?"
-    answer: "It encodes 128 bits of entropy by the BIP-39 standard, which is comparable to a long generated password. The strength is in the entropy, not the word count — fewer words means weaker. Most modern wallets and tene default to 12, which is the practical sweet spot between security and writeability."
-  - question: "What if my recovery key falls into the wrong hands?"
-    answer: "It grants full vault access, exactly like the master password. Treat the 12 words as you would your master credentials — never store them in the same place as the vault file, never paste them into a chat or AI agent, and never photograph them with a phone that auto-uploads to the cloud."
-  - question: "Why not just use a key-file backup instead?"
-    answer: "A key file is brittle: it lives on the same kind of disk that just failed, it has no checksum to detect bit-rot, and it cannot be split across locations easily. A 12-word phrase can be hand-written, printed, memorized, or stamped into metal — it survives hardware failure that a key file does not."
-  - question: "Does the recovery key still work after my laptop dies?"
-    answer: "Only if the vault file itself was backed up. The recovery key recovers access to a vault — it does not regenerate the encrypted data. Back up the encrypted vault file separately; ciphertext is safe to push anywhere, including a public bucket."
+  - question: Is a 12-word recovery key as strong as my master password?
+    answer: >-
+      It encodes 128 bits of entropy by the BIP-39 standard, which is comparable
+      to a long generated password. The strength is in the entropy, not the word
+      count — fewer words means weaker. Most modern wallets and tene default to
+      12, which is the practical sweet spot between security and writeability.
+  - question: What if my recovery key falls into the wrong hands?
+    answer: >-
+      It grants full vault access, exactly like the master password. Treat the
+      12 words as you would your master credentials — never store them in the
+      same place as the vault file, never paste them into a chat or AI agent,
+      and never photograph them with a phone that auto-uploads to the cloud.
+  - question: Why not just use a key-file backup instead?
+    answer: >-
+      A key file is brittle: it lives on the same kind of disk that just failed,
+      it has no checksum to detect bit-rot, and it cannot be split across
+      locations easily. A 12-word phrase can be hand-written, printed,
+      memorized, or stamped into metal — it survives hardware failure that a key
+      file does not.
+  - question: Does the recovery key still work after my laptop dies?
+    answer: >-
+      Only if the vault file itself was backed up. The recovery key recovers
+      access to a vault — it does not regenerate the encrypted data. Back up the
+      encrypted vault file separately; ciphertext is safe to push anywhere,
+      including a public bucket.
 ---
 
 ## A short answer up front
@@ -325,6 +348,25 @@ promise that for future you.
 **Vault key** — The 256-bit random key that actually encrypts your secrets. It's
   never stored in the clear; only the wrapped (locked) copies sit
   on disk.
+
+## FAQ
+
+**Is a 12-word recovery key as strong as my master password?**
+
+It encodes 128 bits of entropy by the BIP-39 standard, which is comparable to a long generated password. The strength is in the entropy, not the word count — fewer words means weaker. Most modern wallets and tene default to 12, which is the practical sweet spot between security and writeability.
+
+**What if my recovery key falls into the wrong hands?**
+
+It grants full vault access, exactly like the master password. Treat the 12 words as you would your master credentials — never store them in the same place as the vault file, never paste them into a chat or AI agent, and never photograph them with a phone that auto-uploads to the cloud.
+
+**Why not just use a key-file backup instead?**
+
+A key file is brittle: it lives on the same kind of disk that just failed, it has no checksum to detect bit-rot, and it cannot be split across locations easily. A 12-word phrase can be hand-written, printed, memorized, or stamped into metal — it survives hardware failure that a key file does not.
+
+**Does the recovery key still work after my laptop dies?**
+
+Only if the vault file itself was backed up. The recovery key recovers access to a vault — it does not regenerate the encrypted data. Back up the encrypted vault file separately; ciphertext is safe to push anywhere, including a public bucket.
+
 
 Related reading:
 - [XChaCha20-Poly1305 for developers](/blog/xchacha20-for-devs)

--- a/apps/web/content/blog/spec-driven-coding-with-claude-code.mdx
+++ b/apps/web/content/blog/spec-driven-coding-with-claude-code.mdx
@@ -1,23 +1,49 @@
 ---
 slug: spec-driven-coding-with-claude-code
-title: "Spec-driven coding with Claude Code: write the spec, ship the diff"
-description: "Vibe-coding peaks when the spec is written first. The minimum viable spec, why Claude Code rewards it more than other agents, and where it stops paying off."
-publishedAt: "2026-04-28"
-updatedAt: "2026-04-28"
+title: 'Spec-driven coding with Claude Code: write the spec, ship the diff'
+description: >-
+  Vibe-coding peaks when the spec is written first. The minimum viable spec, why
+  Claude Code rewards it more than other agents, and where it stops paying off.
+publishedAt: '2026-04-28'
+updatedAt: '2026-04-28'
 category: vibe-coding
-tags: ["workflow", "harness-engineering", "claude-code", "deep-dive"]
-author: "agent-kay"
-cover: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/spec-driven-coding-with-claude-code"
+tags:
+  - workflow
+  - harness-engineering
+  - claude-code
+  - deep-dive
+author: agent-kay
+cover: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/spec-driven-coding-with-claude-code'
 faqs:
-  - question: "Is this just waterfall renamed?"
-    answer: "No. Waterfall freezes the spec for a quarter and ships once. Spec-driven coding freezes the spec for a single change and re-runs the loop hourly. The unit of planning shrunk from a release to a feature, then to a single PR. The spec is short-lived, written for the next two hours of work, and discarded after the merge."
-  - question: "Does this approach work with Cursor or Cline too?"
-    answer: "It works, but not as crisply. Claude Code's long-running session, persistent project state, and multi-file edit semantics line up with spec-driven loops better than turn-based editors. With Cursor you can replicate ~70% of the win by pasting the spec at the top of the chat; with Cline the agentic loop is more compatible but the project context surface is smaller. The pattern is portable, the gain is not uniform."
-  - question: "How long should a spec be?"
-    answer: "If you cannot read the spec aloud in under 90 seconds, it is too long for a single change. The minimum viable spec for a feature is roughly 200–400 words of plain English plus a 5-line interface sketch. Everything beyond that should be in code, not in a doc."
-  - question: "What if the spec changes mid-implementation?"
-    answer: "That is a signal you discovered something the spec missed. Pause, edit the spec in place, re-prompt the agent against the updated spec. Do not let the implementation drift away from the spec — the spec is the source of truth for *this loop*. It will be discarded after the merge, so there is no historical-record cost to editing it."
+  - question: Is this just waterfall renamed?
+    answer: >-
+      No. Waterfall freezes the spec for a quarter and ships once. Spec-driven
+      coding freezes the spec for a single change and re-runs the loop hourly.
+      The unit of planning shrunk from a release to a feature, then to a single
+      PR. The spec is short-lived, written for the next two hours of work, and
+      discarded after the merge.
+  - question: Does this approach work with Cursor or Cline too?
+    answer: >-
+      It works, but not as crisply. Claude Code's long-running session,
+      persistent project state, and multi-file edit semantics line up with
+      spec-driven loops better than turn-based editors. With Cursor you can
+      replicate ~70% of the win by pasting the spec at the top of the chat; with
+      Cline the agentic loop is more compatible but the project context surface
+      is smaller. The pattern is portable, the gain is not uniform.
+  - question: How long should a spec be?
+    answer: >-
+      If you cannot read the spec aloud in under 90 seconds, it is too long for
+      a single change. The minimum viable spec for a feature is roughly 200–400
+      words of plain English plus a 5-line interface sketch. Everything beyond
+      that should be in code, not in a doc.
+  - question: What if the spec changes mid-implementation?
+    answer: >-
+      That is a signal you discovered something the spec missed. Pause, edit the
+      spec in place, re-prompt the agent against the updated spec. Do not let
+      the implementation drift away from the spec — the spec is the source of
+      truth for *this loop*. It will be discarded after the merge, so there is
+      no historical-record cost to editing it.
 ---
 
 ## The bug-fix loop you keep ending up in
@@ -125,6 +151,25 @@ The other compounding win is on the human. Writing four-section specs for two mo
 **Re-anchor** — A one-line prompt that points the agent back at the spec ("re-read the constraint section, then fix the diff").
 
 **Forcing function** — A tool or rule that makes you do something useful as a side effect of using it. The agent is one for the writing habit.
+
+## FAQ
+
+**Is this just waterfall renamed?**
+
+No. Waterfall freezes the spec for a quarter and ships once. Spec-driven coding freezes the spec for a single change and re-runs the loop hourly. The unit of planning shrunk from a release to a feature, then to a single PR. The spec is short-lived, written for the next two hours of work, and discarded after the merge.
+
+**Does this approach work with Cursor or Cline too?**
+
+It works, but not as crisply. Claude Code's long-running session, persistent project state, and multi-file edit semantics line up with spec-driven loops better than turn-based editors. With Cursor you can replicate ~70% of the win by pasting the spec at the top of the chat; with Cline the agentic loop is more compatible but the project context surface is smaller. The pattern is portable, the gain is not uniform.
+
+**How long should a spec be?**
+
+If you cannot read the spec aloud in under 90 seconds, it is too long for a single change. The minimum viable spec for a feature is roughly 200–400 words of plain English plus a 5-line interface sketch. Everything beyond that should be in code, not in a doc.
+
+**What if the spec changes mid-implementation?**
+
+That is a signal you discovered something the spec missed. Pause, edit the spec in place, re-prompt the agent against the updated spec. Do not let the implementation drift away from the spec — the spec is the source of truth for *this loop*. It will be discarded after the merge, so there is no historical-record cost to editing it.
+
 
 Related reading:
 - [bkit + harness engineering: workflow beats model choice](/blog/bkit-harness-engineering-vibe-coding)

--- a/apps/web/content/blog/vibe-coded-apps-leak-keys-data.mdx
+++ b/apps/web/content/blog/vibe-coded-apps-leak-keys-data.mdx
@@ -1,20 +1,36 @@
 ---
 slug: vibe-coded-apps-leak-keys-data
-title: "60% of vibe-coded apps leak API keys. Here's the missing step."
-description: "A Q1 2026 audit found 60%+ of vibe-coded apps ship API keys to public repos. Discipline isn't the fix — workflow is. The 60-second swap that ends it."
-publishedAt: "2026-04-30"
-updatedAt: "2026-04-30"
+title: 60% of vibe-coded apps leak API keys. Here's the missing step.
+description: >-
+  A Q1 2026 audit found 60%+ of vibe-coded apps ship API keys to public repos.
+  Discipline isn't the fix — workflow is. The 60-second swap that ends it.
+publishedAt: '2026-04-30'
+updatedAt: '2026-04-30'
 category: vibe-coding
-tags: [tene, security, devsecops, workflow]
-author: "agent-kay"
-thumbnail: "/demo/dotenv-gone-demo.gif"
+tags:
+  - tene
+  - security
+  - devsecops
+  - workflow
+author: agent-kay
+thumbnail: /demo/dotenv-gone-demo.gif
 faqs:
-  - question: "Does tene work with Cursor and Claude Code?"
-    answer: "Yes. tene injects secrets as environment variables, and both editors' agents inherit those values when they run your build, test, or dev commands. The agent never opens the vault file directly."
-  - question: "What if I already pushed `.env` to a public repo?"
-    answer: "Rotate every key shown in the leaked file at its provider (Stripe, OpenAI, AWS, etc.). Then run tene import .env from a fresh checkout and delete the .env file. Past leaks are permanent — only future commits are protected."
-  - question: "Where does the 60% number come from?"
-    answer: "It's from a Q1 2026 audit of vibe-coded apps cited by The Next Web and Threat Landscape after the Lovable BOLA disclosure in late April. Independent surveys from earlier in 2026 show similar magnitude (40–70% range across samples)."
+  - question: Does tene work with Cursor and Claude Code?
+    answer: >-
+      Yes. tene injects secrets as environment variables, and both editors'
+      agents inherit those values when they run your build, test, or dev
+      commands. The agent never opens the vault file directly.
+  - question: What if I already pushed `.env` to a public repo?
+    answer: >-
+      Rotate every key shown in the leaked file at its provider (Stripe, OpenAI,
+      AWS, etc.). Then run tene import .env from a fresh checkout and delete the
+      .env file. Past leaks are permanent — only future commits are protected.
+  - question: Where does the 60% number come from?
+    answer: >-
+      It's from a Q1 2026 audit of vibe-coded apps cited by The Next Web and
+      Threat Landscape after the Lovable BOLA disclosure in late April.
+      Independent surveys from earlier in 2026 show similar magnitude (40–70%
+      range across samples).
 ---
 
 ## The week 60% became a number
@@ -236,6 +252,21 @@ risks went away.
 
 If your project still has a `.env` next to its README this evening, you
 already know the next step.
+
+## FAQ
+
+**Does tene work with Cursor and Claude Code?**
+
+Yes. tene injects secrets as environment variables, and both editors' agents inherit those values when they run your build, test, or dev commands. The agent never opens the vault file directly.
+
+**What if I already pushed `.env` to a public repo?**
+
+Rotate every key shown in the leaked file at its provider (Stripe, OpenAI, AWS, etc.). Then run tene import .env from a fresh checkout and delete the .env file. Past leaks are permanent — only future commits are protected.
+
+**Where does the 60% number come from?**
+
+It's from a Q1 2026 audit of vibe-coded apps cited by The Next Web and Threat Landscape after the Lovable BOLA disclosure in late April. Independent surveys from earlier in 2026 show similar magnitude (40–70% range across samples).
+
 
 Related reading:
 - [How AI agents read your `.env` — and why it's not their fault](/blog/ai-reads-env)

--- a/apps/web/content/blog/vibe-coding-with-context-engineering.mdx
+++ b/apps/web/content/blog/vibe-coding-with-context-engineering.mdx
@@ -1,23 +1,51 @@
 ---
 slug: vibe-coding-with-context-engineering
-title: "Vibe coding with context engineering: 1 person, 9 sprints, 1 day"
-description: "3,514 messages, 28 days, 9 sprints shipped in a single session — the 4-layer context stack a solo founder uses so AI does the execution and the human still owns the call."
-publishedAt: "2026-04-29"
-updatedAt: "2026-04-29"
+title: 'Vibe coding with context engineering: 1 person, 9 sprints, 1 day'
+description: >-
+  3,514 messages, 28 days, 9 sprints shipped in a single session — the 4-layer
+  context stack a solo founder uses so AI does the execution and the human still
+  owns the call.
+publishedAt: '2026-04-29'
+updatedAt: '2026-04-29'
 category: philosophy
-tags: ["bkit", "founder-story", "workflow", "claude-code"]
-author: "agent-kay"
-thumbnail: "/blog/vibe-coding-with-context-engineering/solo-orchestration.webp"
-canonicalUrl: "https://tene.sh/blog/vibe-coding-with-context-engineering"
+tags:
+  - bkit
+  - founder-story
+  - workflow
+  - claude-code
+author: agent-kay
+thumbnail: /blog/vibe-coding-with-context-engineering/solo-orchestration.webp
+canonicalUrl: 'https://tene.sh/blog/vibe-coding-with-context-engineering'
 faqs:
-  - question: "Doesn't this mean Claude does everything and you do nothing?"
-    answer: "It's the opposite. The more execution Claude takes over, the higher the share of work that is *judgment* — direction, quality bar, convention trade-offs, noticing what is missing. 25 person-weeks did not become 0.2 person-weeks because the code volume shrunk. It happened because the decision density was compressed into one head."
-  - question: "Why not just use Cursor or Copilot — why all this context engineering setup?"
-    answer: "Cursor and Copilot are turn-based assistants. The stack in this article assumes a long-horizon orchestrator — one session running 9 sprints × 7 PDCA phases = 63 phase transitions. That requires *project-scoped* context, not conversation-scoped context. They are different tools. You can run both."
-  - question: "What if my project has no docs, no rules, no .claude/ setup?"
-    answer: "Spend 70% of your first sprint building the stack itself. It feels wasteful. From the second sprint on, you get it back with interest. The 9-sprint-in-a-day speed is the compound result of six prior weeks of stack accumulation, not raw model speed. Context engineering is an asset that grows — not a tool you reach for once."
-  - question: "Did the 682GB recursion bug not break your trust in AI?"
-    answer: "It reinforced it. AI running solo will produce that class of bug — the data confirmed it. Which is exactly why the PDCA Check phase has automated gates and the human still asks 'are you really done?' three times. Pushback is not skepticism. It is protocol."
+  - question: Doesn't this mean Claude does everything and you do nothing?
+    answer: >-
+      It's the opposite. The more execution Claude takes over, the higher the
+      share of work that is *judgment* — direction, quality bar, convention
+      trade-offs, noticing what is missing. 25 person-weeks did not become 0.2
+      person-weeks because the code volume shrunk. It happened because the
+      decision density was compressed into one head.
+  - question: >-
+      Why not just use Cursor or Copilot — why all this context engineering
+      setup?
+    answer: >-
+      Cursor and Copilot are turn-based assistants. The stack in this article
+      assumes a long-horizon orchestrator — one session running 9 sprints × 7
+      PDCA phases = 63 phase transitions. That requires *project-scoped*
+      context, not conversation-scoped context. They are different tools. You
+      can run both.
+  - question: 'What if my project has no docs, no rules, no .claude/ setup?'
+    answer: >-
+      Spend 70% of your first sprint building the stack itself. It feels
+      wasteful. From the second sprint on, you get it back with interest. The
+      9-sprint-in-a-day speed is the compound result of six prior weeks of stack
+      accumulation, not raw model speed. Context engineering is an asset that
+      grows — not a tool you reach for once.
+  - question: Did the 682GB recursion bug not break your trust in AI?
+    answer: >-
+      It reinforced it. AI running solo will produce that class of bug — the
+      data confirmed it. Which is exactly why the PDCA Check phase has automated
+      gates and the human still asks 'are you really done?' three times.
+      Pushback is not skepticism. It is protocol.
 ---
 
 ## The lonely sprint
@@ -258,6 +286,25 @@ That's what `tene` and `bkit` are, in the end — opinionated context engineerin
 **Quality gate** — An automated check that blocks a phase from advancing until the result passes a threshold (e.g., 0 typecheck errors).
 
 **Multi-clauding** — Running several Claude sessions in parallel on different parts of the project at the same time.
+
+## FAQ
+
+**Doesn't this mean Claude does everything and you do nothing?**
+
+It's the opposite. The more execution Claude takes over, the higher the share of work that is *judgment* — direction, quality bar, convention trade-offs, noticing what is missing. 25 person-weeks did not become 0.2 person-weeks because the code volume shrunk. It happened because the decision density was compressed into one head.
+
+**Why not just use Cursor or Copilot — why all this context engineering setup?**
+
+Cursor and Copilot are turn-based assistants. The stack in this article assumes a long-horizon orchestrator — one session running 9 sprints × 7 PDCA phases = 63 phase transitions. That requires *project-scoped* context, not conversation-scoped context. They are different tools. You can run both.
+
+**What if my project has no docs, no rules, no .claude/ setup?**
+
+Spend 70% of your first sprint building the stack itself. It feels wasteful. From the second sprint on, you get it back with interest. The 9-sprint-in-a-day speed is the compound result of six prior weeks of stack accumulation, not raw model speed. Context engineering is an asset that grows — not a tool you reach for once.
+
+**Did the 682GB recursion bug not break your trust in AI?**
+
+It reinforced it. AI running solo will produce that class of bug — the data confirmed it. Which is exactly why the PDCA Check phase has automated gates and the human still asks 'are you really done?' three times. Pushback is not skepticism. It is protocol.
+
 
 Related reading:
 - [bkit + harness engineering: workflow beats model choice](/blog/bkit-harness-engineering-vibe-coding)

--- a/apps/web/content/blog/web-basics-for-vibe-coders.mdx
+++ b/apps/web/content/blog/web-basics-for-vibe-coders.mdx
@@ -1,21 +1,42 @@
 ---
 slug: web-basics-for-vibe-coders
-title: "Web basics for vibe coders: from localhost to production"
-description: "AI wrote your code. Now how do you ship it to the internet? A plain-language tour of client/server, frontend/backend, database, deployment, and the security gap most AI tutorials skip."
-publishedAt: "2026-04-24"
-updatedAt: "2026-04-24"
+title: 'Web basics for vibe coders: from localhost to production'
+description: >-
+  AI wrote your code. Now how do you ship it to the internet? A plain-language
+  tour of client/server, frontend/backend, database, deployment, and the
+  security gap most AI tutorials skip.
+publishedAt: '2026-04-24'
+updatedAt: '2026-04-24'
 category: engineering
-tags: ["architecture", "tutorial", "security", "tene"]
-author: "agent-kay"
-cover: "/og-image.webp"
-canonicalUrl: "https://tene.sh/blog/web-basics-for-vibe-coders"
+tags:
+  - architecture
+  - tutorial
+  - security
+  - tene
+author: agent-kay
+cover: /og-image.webp
+canonicalUrl: 'https://tene.sh/blog/web-basics-for-vibe-coders'
 faqs:
-  - question: "I built an app with AI. Why can't my friends use it?"
-    answer: "Your app is running on localhost — a loopback address that only resolves on your own machine. 'Shipping' means running that code on a server that's reachable from the public internet at a stable URL. Vercel, Fly.io, Railway, and AWS all solve this in different ways; the one-click options are fine to start."
-  - question: "Do I really need a backend? My app only has a few pages."
-    answer: "No, not always. If your pages are purely static content (marketing site, blog, portfolio), a frontend on Vercel is enough. You need a backend the moment you store data per user, call a paid API that must keep its key secret, or process payments. The moment you have an API key that must not leak, you also inherit the secret-management problem."
-  - question: "Can my AI agent see my .env file while coding?"
-    answer: "Yes, by default. Claude Code, Cursor, Windsurf, and similar tools index project files to build context — .env at the project root is included unless explicitly excluded. This is the biggest security gap in the vibe-coder workflow, and the reason tene exists."
+  - question: I built an app with AI. Why can't my friends use it?
+    answer: >-
+      Your app is running on localhost — a loopback address that only resolves
+      on your own machine. 'Shipping' means running that code on a server that's
+      reachable from the public internet at a stable URL. Vercel, Fly.io,
+      Railway, and AWS all solve this in different ways; the one-click options
+      are fine to start.
+  - question: Do I really need a backend? My app only has a few pages.
+    answer: >-
+      No, not always. If your pages are purely static content (marketing site,
+      blog, portfolio), a frontend on Vercel is enough. You need a backend the
+      moment you store data per user, call a paid API that must keep its key
+      secret, or process payments. The moment you have an API key that must not
+      leak, you also inherit the secret-management problem.
+  - question: Can my AI agent see my .env file while coding?
+    answer: >-
+      Yes, by default. Claude Code, Cursor, Windsurf, and similar tools index
+      project files to build context — .env at the project root is included
+      unless explicitly excluded. This is the biggest security gap in the
+      vibe-coder workflow, and the reason tene exists.
 ---
 
 ## The moment AI finishes your app
@@ -372,6 +393,21 @@ learn them once and they apply to every future project.
 
 **Object storage** — A separate service for big binary files (images, videos). You
   store the file there and keep only the URL in your database.
+
+## FAQ
+
+**I built an app with AI. Why can't my friends use it?**
+
+Your app is running on localhost — a loopback address that only resolves on your own machine. 'Shipping' means running that code on a server that's reachable from the public internet at a stable URL. Vercel, Fly.io, Railway, and AWS all solve this in different ways; the one-click options are fine to start.
+
+**Do I really need a backend? My app only has a few pages.**
+
+No, not always. If your pages are purely static content (marketing site, blog, portfolio), a frontend on Vercel is enough. You need a backend the moment you store data per user, call a paid API that must keep its key secret, or process payments. The moment you have an API key that must not leak, you also inherit the secret-management problem.
+
+**Can my AI agent see my .env file while coding?**
+
+Yes, by default. Claude Code, Cursor, Windsurf, and similar tools index project files to build context — .env at the project root is included unless explicitly excluded. This is the biggest security gap in the vibe-coder workflow, and the reason tene exists.
+
 
 Related reading:
 - [Your .env is not a secret. AI can read it.](/blog/ai-reads-env)

--- a/apps/web/content/blog/xchacha20-for-devs.mdx
+++ b/apps/web/content/blog/xchacha20-for-devs.mdx
@@ -1,22 +1,39 @@
 ---
 slug: xchacha20-for-devs
-title: "XChaCha20-Poly1305 for developers: why it is the right choice for local secrets"
-description: "A practical explanation of XChaCha20-Poly1305 and why tene picked it over AES-GCM for a local-first secret vault. No PhD required."
-publishedAt: "2026-04-21"
-updatedAt: "2026-04-21"
+title: >-
+  XChaCha20-Poly1305 for developers: why it is the right choice for local
+  secrets
+description: >-
+  A practical explanation of XChaCha20-Poly1305 and why tene picked it over
+  AES-GCM for a local-first secret vault. No PhD required.
+publishedAt: '2026-04-21'
+updatedAt: '2026-04-21'
 category: engineering
-tags: ["cryptography", "architecture", "security", "tene"]
-author: "agent-kay"
-cover: "/og-image.webp"
-thumbnail: "/demo/security-proof-demo.gif"
-canonicalUrl: "https://tene.sh/blog/xchacha20-for-devs"
+tags:
+  - cryptography
+  - architecture
+  - security
+  - tene
+author: agent-kay
+cover: /og-image.webp
+thumbnail: /demo/security-proof-demo.gif
+canonicalUrl: 'https://tene.sh/blog/xchacha20-for-devs'
 faqs:
-  - question: "Is XChaCha20-Poly1305 better than AES-GCM?"
-    answer: "On a CPU without an AES hardware booster, ChaCha20 is faster and easier to write safely. For a local CLI vault on a developer laptop, XChaCha20-Poly1305 is the simpler, more portable pick."
-  - question: "Why not just use libsodium?"
-    answer: "tene uses golang.org/x/crypto/chacha20poly1305, a reviewed Go library. libsodium would force a C dependency, which makes it harder to ship tene as a single static binary."
-  - question: "What does 'extended nonce' buy you?"
-    answer: "XChaCha20 uses a 192-bit nonce instead of the regular 96. With 192 bits you can pick nonces at random and never have to think about clashes. With 96 bits you have to be careful."
+  - question: Is XChaCha20-Poly1305 better than AES-GCM?
+    answer: >-
+      On a CPU without an AES hardware booster, ChaCha20 is faster and easier to
+      write safely. For a local CLI vault on a developer laptop,
+      XChaCha20-Poly1305 is the simpler, more portable pick.
+  - question: Why not just use libsodium?
+    answer: >-
+      tene uses golang.org/x/crypto/chacha20poly1305, a reviewed Go library.
+      libsodium would force a C dependency, which makes it harder to ship tene
+      as a single static binary.
+  - question: What does 'extended nonce' buy you?
+    answer: >-
+      XChaCha20 uses a 192-bit nonce instead of the regular 96. With 192 bits
+      you can pick nonces at random and never have to think about clashes. With
+      96 bits you have to be careful.
 ---
 
 ## A short answer up front
@@ -256,6 +273,21 @@ tene repo if you want to read it.
 **Birthday bound** — A counting result. Roughly: with N possible nonces, you expect a
   random clash after about √N picks. For a 96-bit nonce that's 2⁴⁸,
   for a 192-bit nonce it's 2⁹⁶.
+
+## FAQ
+
+**Is XChaCha20-Poly1305 better than AES-GCM?**
+
+On a CPU without an AES hardware booster, ChaCha20 is faster and easier to write safely. For a local CLI vault on a developer laptop, XChaCha20-Poly1305 is the simpler, more portable pick.
+
+**Why not just use libsodium?**
+
+tene uses golang.org/x/crypto/chacha20poly1305, a reviewed Go library. libsodium would force a C dependency, which makes it harder to ship tene as a single static binary.
+
+**What does 'extended nonce' buy you?**
+
+XChaCha20 uses a 192-bit nonce instead of the regular 96. With 192 bits you can pick nonces at random and never have to think about clashes. With 96 bits you have to be careful.
+
 
 Related reading:
 - [How AI agents read your `.env`](/blog/ai-reads-env)

--- a/apps/web/scripts/backfill-faq.mjs
+++ b/apps/web/scripts/backfill-faq.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// One-time backfill: ensure every blog post with frontmatter `faqs:` has a
+// matching `## FAQ` section in the body that mirrors Q+A byte-for-byte.
+// Idempotent — replaces any existing `## FAQ` block in place, so repeated
+// runs converge on the same output.
+//
+// Why this exists: the postbuild verifier (verify-blog-indexability.mjs
+// §FAQ-mirror) requires every Question/Answer in FAQPage JSON-LD to
+// appear as visible text in the same HTML. Frontmatter is the source of
+// truth; this script keeps body content in sync after schema changes.
+//
+// MDX gotcha: bare `<command>` / `<key>` etc. in prose are parsed as JSX
+// elements and crash the build. Frontmatter answers stay raw (matching
+// JSON-LD). When we render them into the body, we escape `<` and `>` to
+// HTML entities — MDX treats those as literal characters, and the
+// post-render visible text decodes back to `<command>`, so the
+// FAQ-mirror substring match still works.
+//
+// Run: `node scripts/backfill-faq.mjs` (from apps/web).
+
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+const CONTENT_DIR = path.resolve("content/blog");
+const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".mdx"));
+
+// Escape characters MDX interprets as JSX / expression syntax in plain
+// prose. Use backslash escapes (the MDX-spec way) — entity escapes don't
+// work because MDX 3 decodes entities before the JSX check, so
+// `&lt;command&gt;` still triggers the JSX parser. Backslash escapes are
+// stripped before rendering, so the visible HTML text matches the
+// frontmatter answer byte-for-byte.
+function escapeForMdxProse(s) {
+  return s
+    .replace(/</g, "\\<")
+    .replace(/>/g, "\\>")
+    .replace(/\{/g, "\\{")
+    .replace(/\}/g, "\\}");
+}
+
+// Strip an existing `## FAQ` block (everything until the next h2 or the
+// `Related reading:` line). Lets repeated runs converge on the same
+// output regardless of prior state.
+function stripFaqSection(content) {
+  // /g flag — strip ALL occurrences (earlier broken runs may have stacked
+  // multiple ## FAQ sections; we converge to a single block).
+  return content.replace(
+    /\n##\s+FAQ\s*\n[\s\S]*?(?=\n##\s|\nRelated reading:|$)/g,
+    "\n",
+  );
+}
+
+let modified = 0,
+  skipped = 0;
+for (const file of files) {
+  const filePath = path.join(CONTENT_DIR, file);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { data, content } = matter(raw);
+  if (!Array.isArray(data.faqs) || data.faqs.length === 0) {
+    skipped++;
+    continue;
+  }
+  const stripped = stripFaqSection(content);
+  const block = [
+    "",
+    "## FAQ",
+    "",
+    ...data.faqs.flatMap((f) => [
+      `**${escapeForMdxProse(f.question)}**`,
+      "",
+      escapeForMdxProse(f.answer),
+      "",
+    ]),
+  ].join("\n");
+  let updated;
+  const relatedMatch = stripped.match(/\n(Related reading[\s\S]*)$/);
+  if (relatedMatch) {
+    const before = stripped.slice(
+      0,
+      stripped.length - relatedMatch[1].length - 1,
+    );
+    updated = `${before.trimEnd()}\n${block}\n\n${relatedMatch[1]}`;
+  } else {
+    updated = `${stripped.trimEnd()}\n${block}\n`;
+  }
+  const newRaw = matter.stringify(updated, data);
+  fs.writeFileSync(filePath, newRaw, "utf-8");
+  modified++;
+  console.log(`  ✓ ${file} (synced ${data.faqs.length} Q&A)`);
+}
+console.log(
+  `\n${modified} synced, ${skipped} skipped (no faqs[] in frontmatter)`,
+);

--- a/apps/web/scripts/verify-blog-indexability.mjs
+++ b/apps/web/scripts/verify-blog-indexability.mjs
@@ -14,6 +14,12 @@
 //      Results Test rejected date-only `datePublished` / `dateModified`)
 //      → catches the case where a future emission site forgets the
 //        toIsoDateTime() helper and ships date-only strings
+//   6. FAQPage schema-content mismatch (added 2026-05-03 after GSC flagged
+//      "FAQPage 입력란이 중복" caused by JSON-LD Q&A drifting from the
+//      visible <FAQ /> UI on `/`. Same risk class for /blog/{slug} where
+//      frontmatter `faqs:` could ship without a body ## FAQ section.)
+//      → ensures every Question/Answer in any FAQPage appears as visible
+//        text on the same page. See .claude/rules/blog-content.md §10.4.
 //
 // Runs as `npm run verify:blog` and as a postbuild step.
 // Exits non-zero on any violation.
@@ -156,10 +162,141 @@ function walkHtml(dir) {
   return out;
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// FAQPage schema-content mismatch guard. Catches the GSC "FAQPage 입력란이
+// 중복" warning at root cause: every Question/Answer that appears in
+// JSON-LD must also appear as visible text on the page. Otherwise either:
+//   - Google flags "FAQ markup not matching visible content", surfacing as
+//     duplicate-entry warning (multiple FAQPage interpretations)
+//   - Manual penalty for "hidden FAQ markup" — site-wide rich-result block
+// ──────────────────────────────────────────────────────────────────────
+
+// Strip <script>, <style>, all HTML tags, and decode the few HTML entities
+// our content actually uses, so substring matching against the JSON-LD
+// answer text works on the visible body.
+function htmlToText(html) {
+  let t = html;
+  t = t.replace(/<script[\s\S]*?<\/script>/gi, " ");
+  t = t.replace(/<style[\s\S]*?<\/style>/gi, " ");
+  t = t.replace(/<[^>]+>/g, " ");
+  t = t
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&hellip;/g, "…")
+    .replace(/&ldquo;/g, "“")
+    .replace(/&rdquo;/g, "”")
+    .replace(/&lsquo;/g, "‘")
+    .replace(/&rsquo;/g, "’");
+  // Collapse whitespace so JSON-LD literal "two   spaces" matches HTML
+  // text run with arbitrary whitespace.
+  return t.replace(/\s+/g, " ");
+}
+
+// Decode the `\u00xx` escapes Next.js emits inside JSON-LD strings so we
+// can substring-match them against the visible text (which uses the real
+// glyphs). Lightweight — only handles the cases we actually emit.
+function decodeJsonString(s) {
+  return s.replace(/\\u([0-9a-fA-F]{4})/g, (_, h) =>
+    String.fromCharCode(parseInt(h, 16)),
+  );
+}
+
+function extractFaqs(html) {
+  const out = [];
+  const blocks = html.match(
+    /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g,
+  );
+  if (!blocks) return out;
+  for (const block of blocks) {
+    const m = block.match(
+      /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/,
+    );
+    if (!m) continue;
+    let data;
+    try {
+      data = JSON.parse(m[1]);
+    } catch {
+      continue;
+    }
+    const graph = data["@graph"] ? data["@graph"] : [data];
+    for (const node of graph) {
+      if (node["@type"] !== "FAQPage") continue;
+      const entries = Array.isArray(node.mainEntity) ? node.mainEntity : [];
+      for (const q of entries) {
+        out.push({
+          question: decodeJsonString(q.name ?? ""),
+          answer: decodeJsonString(q.acceptedAnswer?.text ?? ""),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+// Normalise text to a tolerant "search canonical" form. Inline markdown
+// formatting (backticks → <code>, bold/italic → <strong>/<em>) is stripped
+// out by htmlToText, so the rendered visible text loses the surrounding
+// markers. Frontmatter answers keep them. We normalise both sides by:
+//   1. Removing inline-formatting punctuation (` * _) so byte-shifts in
+//      formatting don't produce a false negative.
+//   2. Decoding the few entities that may survive ("&quot;", "&#x27;").
+//   3. Collapsing whitespace.
+// The Q&A semantic content is what Google evaluates for FAQPage matching,
+// not the markdown markup used to render it.
+function canon(s) {
+  return (
+    s
+      .replace(/[`*_]/g, "")
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;|&#39;/g, "'")
+      .replace(/\s+/g, " ")
+      // htmlToText replaces `<em>x</em>,` with ` x ,` — collapse the space
+      // it injects before punctuation so the substring match doesn't fail
+      // on inline-formatted phrases.
+      .replace(/\s+([,.!?;:])/g, "$1")
+      .trim()
+  );
+}
+
+function checkFaqMirror(htmlPath) {
+  const html = fs.readFileSync(htmlPath, "utf-8");
+  const rel = path.relative(path.resolve(__dirname, ".."), htmlPath);
+  const faqs = extractFaqs(html);
+  if (faqs.length === 0) return; // no FAQPage on this page → nothing to verify
+  const visibleCanon = canon(htmlToText(html));
+
+  for (const f of faqs) {
+    const qCanon = canon(f.question ?? "");
+    const aCanon = canon(f.answer ?? "");
+    if (qCanon && !visibleCanon.includes(qCanon)) {
+      errors.push(
+        `${rel}: FAQPage question NOT in visible body: "${f.question.slice(0, 80)}…"\n` +
+          `    Add it to the body (## FAQ section) with byte-identical text. ` +
+          `See blog-content.md §10.4.`,
+      );
+    }
+    if (aCanon && !visibleCanon.includes(aCanon)) {
+      errors.push(
+        `${rel}: FAQPage answer NOT in visible body for question "${f.question.slice(0, 60)}…"\n` +
+          `    Add the answer to the body (## FAQ section) with byte-identical text. ` +
+          `See blog-content.md §10.4.`,
+      );
+    }
+  }
+}
+
 if (fs.existsSync(buildDir)) {
   const htmlFiles = walkHtml(buildDir);
-  // Only the surfaces that emit datePublished/dateModified or OG article:*_time.
-  const relevant = htmlFiles.filter((p) => {
+  // Datetime check — only surfaces that emit datePublished/dateModified.
+  const datetimeRelevant = htmlFiles.filter((p) => {
     const rel = path.relative(buildDir, p);
     return (
       rel.startsWith("blog") ||
@@ -168,7 +305,11 @@ if (fs.existsSync(buildDir)) {
       rel.startsWith("vs.html")
     );
   });
-  for (const p of relevant) checkDatetimeFile(p);
+  for (const p of datetimeRelevant) checkDatetimeFile(p);
+
+  // FAQ-mirror check — every page that emits FAQPage. Includes index.html
+  // (`/`) which is the home FAQ surface alongside blog/cli/vs/.
+  for (const p of htmlFiles) checkFaqMirror(p);
 }
 
 if (warnings.length) {

--- a/apps/web/src/components/faq.tsx
+++ b/apps/web/src/components/faq.tsx
@@ -1,12 +1,22 @@
-"use client";
-
-import { useState } from "react";
 import { faqs } from "@/data/faq";
 
-// Design Ref: §4.7 — FAQ with data import, .env risk questions first
+// Design Ref: §4.7 — FAQ with data import, .env risk questions first.
+//
+// Rendered as semantic <details>/<summary> instead of a useState-driven
+// accordion. Two reasons:
+//   1. SSR HTML must contain every answer text. Google's FAQ policy +
+//      Schema.org ↔ visible-content matching require the answers in
+//      <FAQPage> JSON-LD to also appear as visible text on the page. The
+//      previous `{openIndex === i && (...)}` pattern hid all answer text
+//      from SSR output, which the postbuild verifier
+//      (verify-blog-indexability.mjs §FAQ-mirror) rejects.
+//   2. <details> is keyboard- and screen-reader-accessible by default,
+//      with no `aria-expanded` plumbing or focus management code.
+//
+// The chevron rotation is driven by the `details[open]` selector — no
+// React state, no JavaScript needed for the interaction. The block stays
+// a server component (no "use client" directive).
 export function FAQ() {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
-
   return (
     <section id="faq" className="px-4 py-24 sm:px-6">
       <div className="mx-auto max-w-2xl">
@@ -14,32 +24,26 @@ export function FAQ() {
 
         <div className="mt-12 divide-y divide-border">
           {faqs.map((faq, i) => (
-            <div key={i}>
-              <button
-                onClick={() => setOpenIndex(openIndex === i ? null : i)}
-                className="flex w-full items-center justify-between py-5 text-left"
-              >
+            <details key={i} className="group">
+              <summary className="flex cursor-pointer list-none items-center justify-between py-5 text-left">
                 <span className="text-sm font-medium sm:text-base">
                   {faq.question}
                 </span>
                 <svg
-                  className={`h-4 w-4 shrink-0 text-muted transition-transform ${
-                    openIndex === i ? "rotate-180" : ""
-                  }`}
+                  className="h-4 w-4 shrink-0 text-muted transition-transform group-open:rotate-180"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
                   strokeWidth="2"
+                  aria-hidden="true"
                 >
                   <path d="M19 9l-7 7-7-7" />
                 </svg>
-              </button>
-              {openIndex === i && (
-                <p className="pb-5 text-sm leading-relaxed text-muted">
-                  {faq.answer}
-                </p>
-              )}
-            </div>
+              </summary>
+              <p className="pb-5 text-sm leading-relaxed text-muted">
+                {faq.answer}
+              </p>
+            </details>
           ))}
         </div>
       </div>

--- a/apps/web/src/components/seo/home-jsonld.tsx
+++ b/apps/web/src/components/seo/home-jsonld.tsx
@@ -7,62 +7,30 @@
 //
 // Site-wide entities (Organization, WebSite, SoftwareApplication) stay in
 // `layout.tsx` because they are `@id`-keyed and reused across pages.
+//
+// Source-of-truth note (2026-05-03): the FAQ Q&A list is imported from
+// `@/data/faq`, which is the SAME data used by the visible <FAQ /> UI
+// component on the home page. Hardcoding a separate set in this file used
+// to drift — UI showed 8 Q&A while JSON-LD emitted a different 6 Q&A,
+// triggering GSC's "FAQPage 입력란이 중복" / Schema-vs-content mismatch.
+// Per Google policy ("All FAQ markup must match visible content"), the
+// schema must reflect exactly what users see. Importing one array enforces
+// this at build time.
+import { faqs } from "@/data/faq";
 
 const homeJsonLd = {
   "@context": "https://schema.org",
   "@graph": [
     {
       "@type": "FAQPage",
-      mainEntity: [
-        {
-          "@type": "Question",
-          name: "What is Tene?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Tene is a local-first, encrypted secret management CLI. It stores your API keys, tokens, and credentials in an encrypted SQLite vault on your device. No server, no signup, no cloud dependency.",
-          },
+      mainEntity: faqs.map((f) => ({
+        "@type": "Question",
+        name: f.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: f.answer,
         },
-        {
-          "@type": "Question",
-          name: "How does Claude Code auto-detection work?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "When you run tene init, it generates a CLAUDE.md file in your project root. Claude Code reads this file automatically and learns how to use tene to retrieve secrets.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Is Tene free?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Yes, Tene is 100% free and open source under the MIT license. All local features — encryption, runtime injection, multi-environment, AI editor rules — are free forever with no limits.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Will there be team features?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Team sync and collaboration features are being designed. The goal is encrypted team sync without a central server. Join the waitlist at tene.sh to get notified when it launches.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "How are my secrets encrypted?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Tene uses XChaCha20-Poly1305 encryption with 256-bit keys derived from your master password via Argon2id. Each secret gets a unique 192-bit nonce.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Does Tene work offline?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Tene is 100% offline. It makes zero network calls. Your secrets are encrypted and stored locally in a SQLite database.",
-          },
-        },
-      ],
+      })),
     },
     {
       "@type": "HowTo",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -206,6 +206,28 @@ available:
 man tene
 ```
 
+## FAQ
+
+**What is tene?**
+
+tene is a local-first encrypted secret manager CLI. It encrypts API keys with XChaCha20-Poly1305 and injects them at runtime via tene run, so AI coding agents never see plaintext values.
+
+**How do I install tene?**
+
+Run curl -sSfL https://tene.sh/install.sh | sh on macOS or Linux. The installer auto-detects your platform, downloads the latest release binary, and places it on your PATH. No Go toolchain or account is required.
+
+**How do I run a command with secrets injected?**
+
+tene run -- `<command>` launches your command with every secret in the active environment exposed as a process-scoped environment variable. The values never appear on stdout or in shell history. Example: tene run -- npm start.
+
+**Can my AI assistant read tene secrets?**
+
+No. tene get refuses to print secrets to a non-TTY stdout (exit code 2, STDOUT_SECRET_BLOCKED) so an AI agent or log pipeline cannot pipe the value out. Use tene run -- `<command>` instead, which keeps secrets in the child process environment only.
+
+**Where are secrets stored?**
+
+Encrypted in a local SQLite vault at .tene/vault.db, scoped per project directory. The master key is held in your OS keychain (Keychain on macOS, libsecret on Linux, Credential Manager on Windows). A 12-word BIP-39 recovery key is issued on tene init for offline backup.
+
 ## Resources
 
 - Repository: https://github.com/tomo-kay/tene


### PR DESCRIPTION
## Summary

This PR contains two related changes:

### 1. FAQPage duplicate root-cause fix (commit 7795fe2)

GSC flagged "FAQPage 입력란 중복" persistently. Root cause: `home-jsonld.tsx` hardcoded 6 Q&A while the visible `<FAQ>` component rendered 8 different Q&A from `data/faq.ts` — drift between schema and rendered content.

5-layer root-cause fix:
- **Layer 1**: `home-jsonld.tsx` imports `data/faq` SSOT (single source of truth)
- **Layer 2**: `faq.tsx` refactored from `useState` accordion to `<details>/<summary>` so SSR HTML contains every answer as visible text (drops `"use client"`)
- **Layer 3**: `verify-blog-indexability.mjs` extended with FAQ-mirror check (negative-tested — injecting a ghost Q&A into JSON-LD makes the verifier fail)
- **Layer 4**: 20 existing blog posts backfilled with `## FAQ` body section (68 Q&A) via idempotent `backfill-faq.mjs`. Template + rules updated so `/blog-new` cannot regress.
- **Layer 5**: `docs/cli-reference.md` gains `## FAQ` section mirroring `cli-jsonld.tsx` FAQS array

### 2. New blog post: `intent-is-the-new-craft` (commit c616702)

A 2,462-word philosophy essay grounded in 29 days of Claude Code usage data (3,712 messages, 275 commits, 238,530 lines added). 11 h2 sections with 4 FAQs mirrored byte-identical between frontmatter and body.

## Verification

- ✅ `next build` clean (76 SSG pages including new slug)
- ✅ `verify-blog-indexability` — 21 articles all pass (was 20)
- ✅ FAQ schema↔body mirror enforced for every page
- ✅ All datetimes emit full ISO 8601 with timezone
- ✅ Canonical=1, noindex=0, RSS+sitemap include all slugs
- ✅ Chrome MCP QA on localhost:3001: layout contracts intact, console errors 0, all listing pages include the new article

## Test plan

- [ ] CI green (next build + verify:blog + verify:thin all pass)
- [ ] Vercel preview deployment shows the new blog post at `/blog/intent-is-the-new-craft`
- [ ] Schema validator (rich-results.google.com) shows BlogPosting + FAQPage + BreadcrumbList for new slug, no duplicate-input warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)