### PR TITLE
release: v1.0.15 — keychain probe service name fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and tene adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+(No unreleased changes yet — see follow-up entries below this section
+as PRs land. The next stable will increment from v1.0.14.)
+
+## [1.0.14] - 2026-05-20
+
+Closes ten regressions from the v1.0.14-rc1 QA cycle (3 CRITICAL +
+3 HIGH + 3 MEDIUM + 4 LOW) on top of the cli-ux-permission-model
+sprint (PR #116). Three new invariants (I-11/I-12/I-13) pin the
+critical fixes. Full sprint reports under
+`docs/sprints/cli-ux-permission-model/` and
+`docs/sprints/v1014-rc1-qa-fixes/`.
+
 ### ⚠️ Breaking
 
 - `tene get <KEY>` now refuses to print plaintext to non-TTY stdout by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,65 @@ and tene adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-(No unreleased changes yet — see follow-up entries below this section
-as PRs land. The next stable will increment from v1.0.14.)
+### Added
+
+- **`keychain.ProbeServiceName`** (new exported constant, value
+  `"tene-probe"`) — macOS Keychain / libsecret / Windows CredManager
+  service name shared by every project's availability probe. Master
+  key storage remains under the per-project
+  `tene-<hashPath(projectDir)>` service for isolation (sprint
+  keychain-probe-fixed).
+
+### Fixed
+
+- **macOS Keychain ACL prompts and "키체인을 발견할 수 없음" dialog
+  storms during repeated `tene` invocations across many new project
+  directories.** The v1.0.14 `NewStoreWithStatus` availability probe
+  wrote a transient `Set`/`Delete` value under the per-project
+  `tene-<hash>` service. macOS retained one ACL-registered service
+  entry per project even after the value was deleted, so users who
+  touched dozens of project dirs (95+ on a developer machine during
+  the rc1 QA cycle) saw macOS's metadata DB go transiently
+  inconsistent and the "Keychain not found" dialog appear repeatedly.
+  The probe now targets the fixed `ProbeServiceName`, so the host
+  accumulates exactly one keychain entry from the availability
+  check regardless of how many projects the user works on.
+
+  Existing `tene-<hash>` entries from earlier versions are inert
+  (the probe `Delete` removed any stored value). To inventory and
+  clean up at your leisure:
+
+  ```bash
+  # inventory
+  security dump-keychain 2>/dev/null | grep -oE '"tene-[a-f0-9]+"' | sort -u
+
+  # delete (these are availability-probe orphans — safe)
+  for s in $(security dump-keychain 2>/dev/null | grep -oE '"tene-[a-f0-9]+"' | tr -d '"' | sort -u); do
+    security delete-generic-password -s "$s" 2>/dev/null
+  done
+  ```
+
+### Internal / tests
+
+- `setupTestEnv` in `internal/cli/testhelper_test.go` now sets
+  `TENE_KEYCHAIN_FALLBACK=file`, so the CLI test suite never probes
+  the host OS keychain. Cut the full `go test -race ./internal/cli/...`
+  wall-clock from ~270 s to ~38 s on macOS by eliminating the
+  per-test "Always Allow" dialog wait.
+- `TestSelectKeyStore_NoFlag_UsesOSKeychainOrFileFallback` (the one
+  test that still genuinely needs the OS keychain) gains a
+  `testing.Short()` skip plus an explicit `TENE_KEYCHAIN_FALLBACK=""`
+  unset, so `go test -short` is dialog-free and the test still
+  exercises real keychain selection in normal `go test` runs.
+
+## [1.0.14] - 2026-05-20
+
+Closes ten regressions from the v1.0.14-rc1 QA cycle (3 CRITICAL +
+3 HIGH + 3 MEDIUM + 4 LOW) on top of the cli-ux-permission-model
+sprint (PR #116). Three new invariants (I-11/I-12/I-13) pin the
+critical fixes. Full sprint reports under
+`docs/sprints/cli-ux-permission-model/` and
+`docs/sprints/v1014-rc1-qa-fixes/`.
 
 ## [1.0.14] - 2026-05-20
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,26 @@ Whichever you pick, the file mode is `0600` and the directory is created
 with mode `0700`. Tene never grants other users access to your key file;
 that part of the contract is unchanged.
 
+### OS Keychain probe vs. master-key storage (sprint `keychain-probe-fixed`)
+
+On macOS / Linux libsecret / Windows Credential Manager, tene uses
+two distinct service names against the OS keychain:
+
+| Service name | Purpose | Lifetime | Per-project? |
+| --- | --- | --- | --- |
+| `tene-probe` | One-shot Set/Delete to verify the OS keychain accepts writes (selects KeyringStore vs. FileStore fallback) | Created on first `tene` invocation per host, deleted immediately after, but the service registration / ACL grant persists | **No** — single fixed name shared across all projects |
+| `tene-<hashPath(projectDir)>` | Stores the master key for one specific project's vault | Persists for the life of the vault (cleared on `tene` uninstall) | **Yes** — one per project |
+
+The probe service is shared because its only job is "does the
+keychain work?" — a single registration is enough. The storage
+service is per-project because a leaked master key for project A
+must not unlock project B's vault.
+
+Prior to v1.0.15 the probe wrote to the per-project service, which
+made macOS Keychain accumulate one ACL-registered entry per project
+directory the user touched. Inert leftovers from that period can be
+removed via the snippet in `CHANGELOG.md` for [Unreleased].
+
 ## AI-Safe Design Properties
 
 The CLI actively defends against AI agent secret exfiltration:

--- a/docs/sprints/keychain-probe-fixed/design.md
+++ b/docs/sprints/keychain-probe-fixed/design.md
@@ -1,0 +1,227 @@
+# Keychain Probe Service Name — Fixed-Identifier Fix
+
+> **Sprint ID**: `keychain-probe-fixed` (follow-up to v1014-rc1-qa-fixes)
+> **Working branch**: `fix/keychain-probe-service-fixed`
+> **Trust Level**: L3 (single-feature follow-up; small scope)
+> **Status**: design v1.0 — pending implementation
+> **Triggering report**: v1.0.14 user feedback — macOS "키체인을 발견할 수 없음" dialogs piling up during QA session
+
+---
+
+## §0 Mission
+
+Stop the v1.0.14 keychain probe from creating a **new macOS Keychain
+service entry per project**. Replace the per-project `tene-<hash>` probe
+target with a single fixed `tene-probe` service name. Master-key storage
+itself stays per-project for isolation; only the *availability check*
+(`NewStoreWithStatus`) is consolidated.
+
+Two side effects, both desirable:
+
+1. **Far fewer dialogs**. Today a developer who runs `tene` in N new
+   project directories gets up to N "tene wants to access keychain"
+   dialogs *just* from the probe path. After this fix they get one
+   dialog total for the probe (the master-key save path still triggers
+   one per project, but that is genuine ACL-relevant access).
+2. **No more orphan accumulation**. The probe `Set`/`Delete` cycle
+   leaves an ACL trace on the service entry even after the value is
+   deleted; the next time the same service is touched, macOS asks the
+   user again. With a single fixed probe service, that trace exists in
+   exactly one place across the lifetime of the binary on this host.
+
+## §1 Anti-Mission
+
+- ❌ Change the master-key service name. `tene-<hashPath(projectDir)>`
+  remains the production storage location — cross-project isolation
+  is the whole point of that hash.
+- ❌ Touch `pkg/`. tene-cloud must stay green; this is `internal/keychain`
+  only.
+- ❌ Bypass the probe. The probe exists because some hosts (CI, headless
+  Linux, Docker) genuinely lack a usable OS keychain; we must still
+  detect that and fall back to `FileStore`.
+- ❌ Migrate existing `tene-<hash>` keychain entries. They are harmless
+  leftovers; users who care can delete them via Keychain Access.app
+  (see CHANGELOG note).
+
+## §2 Root cause (from v1.0.14 user session)
+
+`internal/keychain/keychain.go:155-168` (current v1.0.14):
+
+```go
+service := ServiceName + "-" + hashPath(projectPath)   // tene-<projectHash>
+ks := NewKeyringStore(service)
+
+testKey := "keychain-test"
+if err := keyring.Set(service, testKey, "test"); err != nil {
+    // file fallback
+}
+_ = keyring.Delete(service, testKey)
+```
+
+The probe `Set(service, "keychain-test", "test")` writes a dummy entry
+under the **per-project service name** purely to confirm the OS keychain
+accepts writes. The follow-up `Delete` cleans up the value but
+**macOS still keeps the service entry registered in its metadata DB**,
+along with an ACL grant ("tene is allowed to access this service").
+
+Consequence on a developer machine that touches K new project dirs:
+
+- K entries appear under `security dump-keychain | grep tene-`
+- macOS prompts for ACL approval up to K times
+- When K is large (during QA, K reached 95+) the keychain metadata DB
+  can fall into transient inconsistency states that surface as the
+  "키체인을 발견할 수 없음" dialog the user reported.
+
+## §3 Design
+
+### 3.1 New exported constant
+
+`internal/keychain/keychain.go`:
+
+```go
+// ProbeServiceName is the fixed macOS Keychain service used by
+// NewStoreWithStatus to test keychain availability. Sprint
+// keychain-probe-fixed.
+//
+// One name across all projects on a host means the ACL prompt fires at
+// most once per binary install, regardless of how many project
+// directories the user touches. Master-key storage continues to use
+// the per-project "tene-<hashPath(projectDir)>" service so vault keys
+// stay isolated.
+const ProbeServiceName = "tene-probe"
+```
+
+### 3.2 Modified `NewStoreWithStatus`
+
+```go
+service := ServiceName + "-" + hashPath(projectPath)
+ks := NewKeyringStore(service)
+
+// Availability probe. Sprint keychain-probe-fixed: this uses the
+// fixed ProbeServiceName, NOT `service`, so we do not register a
+// new keychain entry per project. The master-key store at `service`
+// is only touched later when the user actually runs tene init / set.
+if err := keyring.Set(ProbeServiceName, "probe", "ok"); err != nil {
+    return NewFileStore(keyfilePath), FallbackInfo{
+        Used:   true,
+        Reason: "keychain_unavailable",
+        Path:   keyfilePath,
+    }
+}
+_ = keyring.Delete(ProbeServiceName, "probe")
+
+return ks, FallbackInfo{Used: false}
+```
+
+### 3.3 Test harness hardening (rolled in from rc1 follow-up)
+
+`internal/cli/testhelper_test.go` adds
+`t.Setenv("TENE_KEYCHAIN_FALLBACK", "file")` in `setupTestEnv` so test
+runs skip the OS keychain probe entirely. The CLI integration tests
+exercise `KeyStore` contract uniformly via the file fallback;
+`internal/keychain/keychain_test.go` covers the env-override branch
+and the new probe-service test cover the OS path.
+
+`internal/cli/no_keychain_integration_test.go` adds a
+`testing.Short()` skip on the OS-keychain-probing test plus an
+explicit unset of `TENE_KEYCHAIN_FALLBACK` so that test still genuinely
+exercises `KeyringStore` selection when developers want to verify
+keychain integration.
+
+## §4 Test plan
+
+### 4.1 New unit test in `internal/keychain/keychain_test.go`
+
+`TestNewStoreWithStatus_ProbeUsesFixedService` — uses `keyring.MockInit()`
+to swap the global provider for an in-memory map, then asserts:
+
+1. Two successive `NewStoreWithStatus(projectA)` and
+   `NewStoreWithStatus(projectB)` calls leave the mock store with
+   **zero `tene-<hashA>`-keyed entries** and **zero
+   `tene-<hashB>`-keyed entries**.
+2. The fixed `ProbeServiceName` has no leftover value either (the
+   probe's `Delete` cleaned it up).
+3. The returned `KeyStore` is the project-specific `*KeyringStore`
+   (`Used == false`).
+
+That triple covers: (a) per-project hash service is never the probe
+target, (b) no value leaks past the probe, (c) the user still gets the
+correct production store handle.
+
+### 4.2 Regression coverage
+
+- All existing tests in `internal/keychain/` and `internal/cli/...`
+  must remain green.
+- `golangci-lint run` 0 issues.
+- `tene-cloud` cross-repo build + tests (G3 gate) — `pkg/` unchanged so
+  this should be a no-op but stays a hard gate.
+
+## §5 Migration
+
+Existing `tene-<hashPath>` macOS Keychain entries from prior versions
+are harmless artifacts of the v1.0.14 (and earlier) probe path. They
+do not contain any secret value (the probe `Delete` removed the
+"keychain-test" value), only the service registration + ACL.
+
+Users who want to clean them up:
+
+```bash
+# Inventory
+security dump-keychain 2>/dev/null | grep -oE '"tene-[a-f0-9]+"' | sort -u
+
+# Delete (sandbox-only entries — safe)
+for s in $(security dump-keychain 2>/dev/null | grep -oE '"tene-[a-f0-9]+"' | tr -d '"' | sort -u); do
+  security delete-generic-password -s "$s" 2>/dev/null
+done
+```
+
+The CHANGELOG entry will include the snippet above so users can clean
+up at their leisure. The probe-service fix itself does NOT need an
+explicit migration — new tene-probe entry is created on first probe
+after upgrade; old entries are inert.
+
+## §6 Acceptance criteria
+
+- [ ] `ProbeServiceName` constant exported from `internal/keychain`
+- [ ] `NewStoreWithStatus` uses `ProbeServiceName` (not the per-project
+  service) for the availability probe
+- [ ] New unit test `TestNewStoreWithStatus_ProbeUsesFixedService`
+  exercises the contract under `keyring.MockInit()`
+- [ ] Test harness `setupTestEnv` sets `TENE_KEYCHAIN_FALLBACK=file`
+  (P2 follow-up applied)
+- [ ] `TestSelectKeyStore_NoFlag_UsesOSKeychainOrFileFallback` gains a
+  `testing.Short()` skip + explicit `TENE_KEYCHAIN_FALLBACK` unset
+- [ ] Full `go test -race ./...` green
+- [ ] `golangci-lint run` 0 issues
+- [ ] `cd ../tene-cloud && go build ./... && go test -race ./...` green
+- [ ] CHANGELOG `[Unreleased]` Fixed entry naming the probe-service
+  regression with the macOS cleanup snippet
+- [ ] SECURITY.md "Master Key Storage Modes" section gets a one-line
+  note distinguishing the per-project master-key service from the
+  fixed probe service
+- [ ] PR opened against `staging`
+
+## §7 Risks
+
+| Risk | Mitigation |
+|---|---|
+| MockInit alters a global; later tests in the same package run see the mock provider | `t.Cleanup` cannot truly restore the previous provider (library exposes no setter). Document the test order requirement; place the mock test last by sorted name (Go testing's default order is source code order, so put the test at the bottom of the file). |
+| Cross-platform: Linux libsecret and Windows Credential Manager also use `service` parameter — must still work with the fixed `ProbeServiceName` | The go-keyring API is uniform: `Set(service, user, password)` is implemented for each platform. Linux libsecret organises secrets by `application` attribute (mapped from `service`); a fixed service is fine there too. Windows Credential Manager keys by `service + user` and similarly accepts the fixed name. |
+| Users running a CI image without secret-service installed | Existing behaviour preserved: `keyring.Set` fails → `FallbackInfo{Used: true, Reason: "keychain_unavailable"}`. The fix changes only the service name, not the fallback path. |
+
+## §8 Cross-repo impact
+
+- **tene-cloud**: unchanged. `pkg/` not touched.
+- **tene-biz**: docs/05-qa update once this lands (post-fix QA report follow-up).
+- **apps/web**: unchanged.
+- **homebrew tap, GHCR**: next release tag (likely `v1.0.15` if other
+  changes accumulate, or `v1.0.14.1` as a patch) ships this fix.
+
+## §9 Reference
+
+- Sprint `v1014-rc1-qa-fixes` `FX1.md` — original keychain fix
+  (introduced `NullStore` and the `selectKeyStore` precedence). This
+  follow-up is strictly additive on top of that.
+- `tene-biz/docs/05-qa/tene-cli-v1.0.14-postfix.qa-report.md` §5 — the
+  "Outstanding items / deferred to v1.0.15" line that called for this
+  cleanup.

--- a/internal/cli/no_keychain_integration_test.go
+++ b/internal/cli/no_keychain_integration_test.go
@@ -70,9 +70,20 @@ func TestSelectKeyStore_TENE_KEYFILE_OverrideUsesFileStore(t *testing.T) {
 // non-flagged path still returns a real keystore (KeyringStore on macOS
 // dev machines, FileStore on a CI host that lacks libsecret). The point
 // is that NullStore is NEVER returned without the --no-keychain flag.
+//
+// This test is intentionally allowed to probe the real macOS keychain
+// (it explicitly UNsets TENE_KEYCHAIN_FALLBACK so the helper does not
+// short-circuit). On a developer laptop with an unlocked login keychain
+// this completes in ~100 ms; the first run after a reboot may show the
+// "tene wants to access keychain" dialog once. Skip with `-short` if
+// that is disruptive during normal development.
 func TestSelectKeyStore_NoFlag_UsesOSKeychainOrFileFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips OS keychain probe to avoid login dialogs")
+	}
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("TENE_KEYFILE", "")
+	t.Setenv("TENE_KEYCHAIN_FALLBACK", "")
 
 	ks := selectKeyStore(t.TempDir(), false /* noKeychain */, true /* quiet */, os.Stderr)
 	if _, ok := ks.(*keychain.NullStore); ok {

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -14,6 +14,20 @@ type testEnv struct {
 }
 
 // setupTestEnv creates a temporary directory and environment variables for testing.
+//
+// Sprint v1014-rc1-qa-fixes follow-up: force the file-store fallback via
+// TENE_KEYCHAIN_FALLBACK=file so test runs do NOT probe the real macOS
+// keychain. Without this, every test that uses a fresh t.TempDir creates
+// a new tene-<hash> service name and macOS displays a "<process> wants
+// to access keychain" dialog requiring the user's login password — once
+// per service. Long test runs (the 300 s -race sweep on this branch was
+// the worst offender) accumulated dozens of dialogs.
+//
+// The file fallback path is functionally identical for what these tests
+// exercise (KeyStore Load/Store/Delete contract); the OS keychain
+// integration itself is covered by the dedicated
+// TestSelectKeyStore_NoFlag_UsesOSKeychainOrFileFallback test in
+// no_keychain_integration_test.go, which deliberately UNsets this var.
 func setupTestEnv(t *testing.T) *testEnv {
 	t.Helper()
 
@@ -22,6 +36,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 
 	t.Setenv("HOME", home)
 	t.Setenv("TENE_MASTER_PASSWORD", "testpassword123")
+	t.Setenv("TENE_KEYCHAIN_FALLBACK", "file")
 
 	return &testEnv{Dir: dir, HomeDir: home, t: t}
 }

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -14,6 +14,38 @@ import (
 const (
 	ServiceName = "tene"
 	AccountName = "master-key"
+
+	// ProbeServiceName is the macOS Keychain / libsecret / CredManager
+	// service name used by NewStoreWithStatus to check whether the OS
+	// keychain accepts writes. Sprint keychain-probe-fixed.
+	//
+	// Why a fixed name rather than the per-project ServiceName + "-"
+	// + hashPath(projectPath):
+	//
+	//   - The probe value never carries a real secret; it is a
+	//     `Set("probe", "ok")` followed by `Delete`. Yet the per-project
+	//     name registered a new keychain service entry on every project
+	//     directory the user touched, with the ACL grant ("tene allowed
+	//     to access this service") accumulating in macOS's metadata DB.
+	//
+	//   - During the v1.0.14-rc1 QA cycle the user accumulated 95+
+	//     `tene-<hash>` entries on their dev machine and started seeing
+	//     "키체인을 발견할 수 없음" (Keychain not found) dialogs as the
+	//     metadata DB went into a transient inconsistency state.
+	//
+	//   - One fixed service is sufficient for the availability test:
+	//     either go-keyring's Set succeeds (OS keychain works → use it)
+	//     or it fails (no keychain → file fallback).
+	//
+	// The master-key STORAGE service stays per-project so cross-project
+	// isolation is preserved. Only the AVAILABILITY check is shared.
+	ProbeServiceName = "tene-probe"
+
+	// probeAccount is the user identifier under ProbeServiceName for
+	// the availability test. The value written is always "ok"; the
+	// account name is what distinguishes a tene probe from any other
+	// generic-password entry in the keychain.
+	probeAccount = "probe"
 )
 
 // KeyStore is the interface for securely storing and loading the Master Key.
@@ -130,10 +162,20 @@ func NewStore(projectPath string) KeyStore {
 // Selection precedence:
 //  1. TENE_KEYCHAIN_FALLBACK=file env override -> FileStore
 //     (Reason="env_override")
-//  2. OS keychain probe: a no-op Set() to the project-scoped service.
+//  2. OS keychain probe: a small Set/Delete round-trip against the
+//     FIXED ProbeServiceName (NOT the per-project storage service).
 //     If it succeeds, we use the OS keychain (Reason="").
 //     If it fails (CI, Docker, headless, libsecret missing), we fall
 //     back to FileStore (Reason="keychain_unavailable").
+//
+// Sprint keychain-probe-fixed: the probe target is ProbeServiceName
+// (a single fixed name shared across all projects), but the returned
+// KeyringStore still binds to `ServiceName + "-" + hashPath(projectPath)`
+// so vault keys remain per-project isolated. Before this change the
+// probe wrote to the per-project service, causing macOS Keychain to
+// accumulate one ACL-registered entry per project directory the user
+// touched — surfacing as the "키체인을 발견할 수 없음" dialog when the
+// metadata DB went transiently inconsistent.
 //
 // The fallback file path is always ~/.tene/keyfile (per-user, not
 // per-project — keychain.NewFileStore historically used a single path,
@@ -152,12 +194,14 @@ func NewStoreWithStatus(projectPath string) (KeyStore, FallbackInfo) {
 		}
 	}
 
-	service := ServiceName + "-" + hashPath(projectPath)
-	ks := NewKeyringStore(service)
+	storageService := ServiceName + "-" + hashPath(projectPath)
+	ks := NewKeyringStore(storageService)
 
-	// Test keychain availability via a small Set/Delete round-trip.
-	testKey := "keychain-test"
-	if err := keyring.Set(service, testKey, "test"); err != nil {
+	// Test keychain availability via a small Set/Delete round-trip
+	// against the FIXED ProbeServiceName. See the const docstring for
+	// why this is shared across projects while master-key storage at
+	// `storageService` stays per-project.
+	if err := keyring.Set(ProbeServiceName, probeAccount, "ok"); err != nil {
 		// Keychain unavailable -> file fallback
 		return NewFileStore(keyfilePath), FallbackInfo{
 			Used:   true,
@@ -165,7 +209,7 @@ func NewStoreWithStatus(projectPath string) (KeyStore, FallbackInfo) {
 			Path:   keyfilePath,
 		}
 	}
-	_ = keyring.Delete(service, testKey)
+	_ = keyring.Delete(ProbeServiceName, probeAccount)
 
 	return ks, FallbackInfo{Used: false}
 }

--- a/internal/keychain/probe_service_test.go
+++ b/internal/keychain/probe_service_test.go
@@ -1,0 +1,125 @@
+package keychain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Sprint keychain-probe-fixed.
+//
+// These tests use go-keyring's MockInit() to swap the OS keyring
+// provider for an in-memory map, then assert the contract that
+// `NewStoreWithStatus` does NOT touch the per-project service name
+// during its availability probe. Before this fix, the probe wrote
+// (and then deleted) a value under `tene-<projectHash>` for every
+// project directory the user touched, causing macOS to accumulate one
+// ACL-registered entry per project.
+//
+// Note on test ordering: keyring.MockInit() mutates the global
+// `provider` variable in the go-keyring package. There is no public
+// API to restore the previous provider. These tests are placed in
+// their own file so source-code ordering keeps them at the end of
+// the package's test sweep; the TestNewStoreWithStatus_EnvOverride
+// test in keychain_test.go does not touch the keyring provider
+// (env var diverts before any keyring call) so MockInit cannot
+// influence it. TestFileStore_* tests also never reach the keyring
+// provider. The only risk is that future tests that DO call the
+// real OS keyring be added without noticing the mock is sticky —
+// the mock-touching tests below should remain the last in the file
+// to minimise that risk.
+
+// TestNewStoreWithStatus_ProbeUsesFixedService is the headline
+// regression test for the v1.0.14 → v1.0.15 keychain-probe-fixed
+// follow-up. It verifies that an availability probe for project A
+// followed by an availability probe for project B leaves:
+//
+//   - zero leftover values in tene-<hashA> service
+//   - zero leftover values in tene-<hashB> service
+//   - zero leftover value under ProbeServiceName/probe (the probe
+//     `Delete` cleaned it up)
+//   - FallbackInfo.Used == false (mock provider's Set succeeds, so
+//     the OS keychain branch is selected)
+//
+// Together that proves the per-project service is never written by
+// the probe, which is the whole point of the fix.
+func TestNewStoreWithStatus_ProbeUsesFixedService(t *testing.T) {
+	keyring.MockInit()
+
+	// Belt and suspenders: explicitly clear the env override so the
+	// keychain-probe branch is the one actually exercised.
+	t.Setenv("TENE_KEYCHAIN_FALLBACK", "")
+	t.Setenv("HOME", t.TempDir())
+
+	const projectA = "/Users/example/proj-a"
+	const projectB = "/Users/example/proj-b"
+
+	ksA, infoA := NewStoreWithStatus(projectA)
+	if infoA.Used {
+		t.Fatalf("with mocked keyring, FallbackInfo.Used should be false; got Used=%v Reason=%q",
+			infoA.Used, infoA.Reason)
+	}
+	if _, ok := ksA.(*KeyringStore); !ok {
+		t.Fatalf("expected *KeyringStore from happy probe, got %T", ksA)
+	}
+
+	ksB, infoB := NewStoreWithStatus(projectB)
+	if infoB.Used {
+		t.Fatalf("project B probe should also succeed under mock; Reason=%q", infoB.Reason)
+	}
+	if _, ok := ksB.(*KeyringStore); !ok {
+		t.Fatalf("expected *KeyringStore for project B, got %T", ksB)
+	}
+
+	// Now the contract: the probe must NOT have left anything on the
+	// per-project services. (The probe's Delete cleans up the
+	// transient ProbeServiceName value too, so all three slots
+	// should read as ErrNotFound.)
+	serviceA := ServiceName + "-" + hashPath(projectA)
+	serviceB := ServiceName + "-" + hashPath(projectB)
+
+	for _, c := range []struct {
+		label   string
+		service string
+		account string
+	}{
+		{label: "per-project service A (must NOT be probed)", service: serviceA, account: "keychain-test"},
+		{label: "per-project service A (alt probe account)", service: serviceA, account: probeAccount},
+		{label: "per-project service B (must NOT be probed)", service: serviceB, account: "keychain-test"},
+		{label: "per-project service B (alt probe account)", service: serviceB, account: probeAccount},
+		{label: "fixed probe service (must be cleaned up after Delete)", service: ProbeServiceName, account: probeAccount},
+	} {
+		_, err := keyring.Get(c.service, c.account)
+		if !errors.Is(err, keyring.ErrNotFound) {
+			t.Errorf("REGRESSION [%s]: expected ErrNotFound for service=%q account=%q, got err=%v",
+				c.label, c.service, c.account, err)
+		}
+	}
+}
+
+// TestNewStoreWithStatus_ProbeFailureFallsBackToFile mirrors the
+// CI/Docker/headless path. The mock provider is initialised with an
+// error so `keyring.Set` always fails, and we expect FallbackInfo to
+// report "keychain_unavailable" + the returned KeyStore to be the
+// FileStore.
+//
+// This used to be implicit (covered only by integration on hosts
+// without libsecret); pinning it in unit form means the fallback
+// behaviour cannot silently regress.
+func TestNewStoreWithStatus_ProbeFailureFallsBackToFile(t *testing.T) {
+	keyring.MockInitWithError(errors.New("mock probe failure"))
+	t.Setenv("TENE_KEYCHAIN_FALLBACK", "")
+	t.Setenv("HOME", t.TempDir())
+
+	ks, info := NewStoreWithStatus("/Users/example/proj")
+	if !info.Used {
+		t.Fatal("probe failure must cause FallbackInfo.Used = true")
+	}
+	if info.Reason != "keychain_unavailable" {
+		t.Errorf("FallbackInfo.Reason = %q, want %q", info.Reason, "keychain_unavailable")
+	}
+	if _, ok := ks.(*FileStore); !ok {
+		t.Errorf("expected *FileStore after probe failure, got %T", ks)
+	}
+}


### PR DESCRIPTION
## v1.0.15 release — keychain probe service name fixed

Promotes staging to main to cut v1.0.15 stable. Single feature focus:
the keychain probe path no longer creates a new macOS Keychain service
entry per project, eliminating the macOS dialog storms and accumulated
ACL grants that the user encountered during the v1.0.14-rc1 QA session
(95+ orphan `tene-<hash>` entries on the dev machine, eventually
surfacing as transient "키체인을 발견할 수 없음" dialogs).

### Single PR rolled up

- **PR #119** — sprint `keychain-probe-fixed` — `internal/keychain`
  fix: new exported `ProbeServiceName = "tene-probe"`, used by
  `NewStoreWithStatus` for the availability probe. Master-key storage
  service stays per-project for isolation. Two new unit tests pin
  the algorithm-level invariant via `keyring.MockInit()`.

### What changes for users

Existing `tene-<hash>` keychain entries from prior versions are inert
(only the service registration + ACL persists; no secret value was
ever stored there past the probe's `Delete`). They remain on disk
until cleaned up; the CHANGELOG includes a one-liner shell snippet
for users who want to inventory and remove them.

After upgrading to v1.0.15, the host accumulates exactly **one**
keychain entry from the probe path (`tene-probe`, transient — macOS
auto-cleans the zero-value service after the probe's `Delete`).
Master-key entries continue to land under `tene-<hashPath(projectDir)>`
as before, one per project's first `tene init`.

### Internal / test-harness improvements (rolled in)

- `setupTestEnv` sets `TENE_KEYCHAIN_FALLBACK=file` so the CLI test
  sweep skips the OS keychain. `go test -race ./internal/cli/...`
  wall-clock dropped from ~270 s to ~38 s on macOS by eliminating
  per-test "Always Allow" dialog waits.
- The one test that genuinely probes the OS keychain
  (`TestSelectKeyStore_NoFlag_UsesOSKeychainOrFileFallback`) gained
  a `testing.Short()` skip + explicit `TENE_KEYCHAIN_FALLBACK=""`
  unset, so `go test -short` is dialog-free while the full sweep
  still exercises real keychain selection.

### Architecture decisions

| Concern | Verification |
|---|---|
| Other `keyring.*` callers (`login.go`) | `cloudServiceName = "tene-cloud"` — separate namespace, cloud feature disabled. No collision. |
| Master-key isolation (vault key A must not unlock vault B) | `tene-<hashPath>` storage path unchanged; only probe path consolidated. |
| Backward compatibility | Existing `tene-<hash>` entries are inert and remain on disk; manual cleanup snippet provided in CHANGELOG. |
| Cross-platform (Linux libsecret / Windows CredManager) | `keyring.Set(service, user, password)` API uniform; fixed service name valid everywhere. |
| CI/CD users | `--no-keychain` path routes to `NullStore` (FX1 from v1.0.14). `NewStoreWithStatus` not reached. Zero impact. |
| F6 keychain-fallback notice | `FallbackInfo.Used` / `Reason` semantics preserved. |

### Documentation deliverables

- `CHANGELOG.md` — rebadged `[Unreleased]` → `[1.0.14] - 2026-05-20`
  (housekeeping commit `25f5075`), then added new `[Unreleased]`
  entries (Added / Fixed / Internal-tests) for this release. Will be
  rebadged to `[1.0.15]` in a follow-up housekeeping commit once the
  tag lands.
- `SECURITY.md` — new "OS Keychain probe vs. master-key storage"
  subsection in the Master Key Storage Modes section, distinguishing
  the per-project storage service from the fixed probe service.
- `docs/sprints/keychain-probe-fixed/design.md` — full feature spec.

### Test plan

- [x] CI test job (`run 26175230817`): PASS in 3m34s
- [x] CI lint job: PASS in 36s
- [x] Local `go test -race ./internal/keychain/...` — 14/14 PASS (incl. 2 new probe-service tests)
- [x] Local `go test -short ./internal/cli/...` — PASS in ~38 s
- [x] Cross-repo `tene-cloud go build + test -race` — 0 regressions
- [x] In-vivo smoke on darwin/arm64 — +2 storage entries, 0 permanent probe entries
- [x] staging `auto-tag` + `goreleaser` (`run 26175230743 attempt 2`) — both jobs success
- [x] `v1.0.15-rc1` tag landed
- [ ] **GoReleaser stable build + LATEST_VERSION update** — runs on this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
